### PR TITLE
Prepare site with Aluminium-SR1 versions

### DIFF
--- a/src/main/java/io/projectreactor/Application.java
+++ b/src/main/java/io/projectreactor/Application.java
@@ -47,6 +47,7 @@ public final class Application {
 		                                 .get("/docs/{module}/{version}/reference", rewrite("/reference", "/reference/docs/index.html"))
 		                                 .get("/docs/{module}/{version}/reference/", rewrite("/reference/", "/reference/docs/index.html"))
 		                                 .get("/docs/{module}/release/api/**", this::repoProxy)
+		                                 .get("/docs/{module}/release/reference/**", this::repoProxy)
 		                                 .get("/docs/{module}/milestone/api/**", this::repoProxy)
 		                                 .get("/docs/{module}/milestone/reference/**", this::repoProxy)
 		                                 .get("/docs/{module}/snapshot/api/**", this::repoProxy)

--- a/src/main/java/io/projectreactor/Module.java
+++ b/src/main/java/io/projectreactor/Module.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+  ~ Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/src/main/resources/modules.yml
+++ b/src/main/resources/modules.yml
@@ -3,40 +3,50 @@ name: core
 groupId: io.projectreactor
 artifactId: reactor-core
 versions:
+  - 3.0.5.RELEASE
   - 3.0.4.RELEASE
   - 3.0.3.RELEASE
+  - 3.0.6.BUILD-SNAPSHOT
   - 3.0.5.BUILD-SNAPSHOT
 ---
 name: test
 groupId: io.projectreactor.addons
 artifactId: reactor-test
 versions:
+#  - 3.0.5.RELEASE
   - 3.0.4.RELEASE
   - 3.0.3.RELEASE
+#  - 3.0.6.BUILD-SNAPSHOT
   - 3.0.5.BUILD-SNAPSHOT
 ---
 name: adapter
 groupId: io.projectreactor.addons
 artifactId: reactor-adapter
 versions:
+#  - 3.0.5.RELEASE
   - 3.0.4.RELEASE
   - 3.0.3.RELEASE
+#  - 3.0.6.BUILD-SNAPSHOT
   - 3.0.5.BUILD-SNAPSHOT
 ---
 name: netty
 groupId: io.projectreactor.ipc
 artifactId: reactor-netty
 versions:
+#  - 0.6.1.RELEASE
   - 0.6.0.RELEASE
   - 0.5.2.RELEASE
+#  - 0.6.2.BUILD-SNAPSHOT
   - 0.6.1.BUILD-SNAPSHOT
 ---
 name: ipc
 groupId: io.projectreactor.ipc
 artifactId: reactor-ipc
 versions:
+#  - 0.6.1.RELEASE
   - 0.6.0.RELEASE
   - 0.5.1.RELEASE
+#  - 0.6.2.BUILD-SNAPSHOT
   - 0.6.1.BUILD-SNAPSHOT
 ---
 name: kafka

--- a/src/main/resources/modules.yml
+++ b/src/main/resources/modules.yml
@@ -13,20 +13,20 @@ name: test
 groupId: io.projectreactor.addons
 artifactId: reactor-test
 versions:
-#  - 3.0.5.RELEASE
+  - 3.0.5.RELEASE
   - 3.0.4.RELEASE
   - 3.0.3.RELEASE
-#  - 3.0.6.BUILD-SNAPSHOT
+  - 3.0.6.BUILD-SNAPSHOT
   - 3.0.5.BUILD-SNAPSHOT
 ---
 name: adapter
 groupId: io.projectreactor.addons
 artifactId: reactor-adapter
 versions:
-#  - 3.0.5.RELEASE
+  - 3.0.5.RELEASE
   - 3.0.4.RELEASE
   - 3.0.3.RELEASE
-#  - 3.0.6.BUILD-SNAPSHOT
+  - 3.0.6.BUILD-SNAPSHOT
   - 3.0.5.BUILD-SNAPSHOT
 ---
 name: netty

--- a/src/main/resources/static/404.html
+++ b/src/main/resources/static/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+  ~ Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -120,7 +120,7 @@
                 </div>
                 <div class="footer-content-text">
                     <span class="licence">Reactor regroups multiple open source projects licensed under the Apache Software License 2.</span>
-                    © 2013-2016 <a href="/">Reactor Project</a>, powered by
+                    © 2013-2017 <a href="/">Reactor Project</a>, powered by
                     <a href="http://pivotal.io/" class="pivotal">Pivotal</a> & <a href="http://spring.io/" class="spring">Spring</a>
                 </div>
             </footer>

--- a/src/main/resources/static/assets/js/app.js
+++ b/src/main/resources/static/assets/js/app.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -88,6 +88,8 @@
                         <div class="details">
                         <span id="author" class="author">Project Reactor reference
                             documentation, code samples, and Javadoc.</span><br>
+                        <span class="version releasetrain hold">Aluminium-SR1</span> projects
+                            are being progressively released.
                         </div>
                     </div>
                 </div>
@@ -100,8 +102,8 @@
                         <div class="title">
                             <h1>Reactor Core</h1>
                             <div class="version">
-                                <span class="version releasetrain">Aluminium</span>
-                                <span class="version">3.0.4.RELEASE</span>
+                                <span class="version releasetrain hold">Aluminium-SR1</span>
+                                <span class="version">3.0.5.RELEASE</span>
                             </div>
                             <p>A Reactive Streams foundation for Java 8</p>
                         </div>

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+  ~ Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -322,7 +322,7 @@
                 </div>
                 <div class="footer-content-text">
                     <span class="licence">Reactor regroups multiple open source projects licensed under the Apache Software License 2.</span>
-                    © 2013-2016 <a href="/">Reactor Project</a>, powered by
+                    © 2013-2017 <a href="/">Reactor Project</a>, powered by
                     <a href="http://pivotal.io/" class="pivotal">Pivotal</a> & <a href="http://spring.io/"
                                                                                   class="spring">Spring</a>
                 </div>

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -190,7 +190,7 @@
                         <div class="title">
                             <h1>Reactor Kafka</h1>
                             <div class="version">
-                                <span class="version releasetrain">Aluminium</span>
+                                <!--<span class="version releasetrain">Aluminium</span>-->
                                 <span class="version">1.0.0.M1</span>
                             </div>
                             <p>Reactive bridge to Apache Kafka</p>

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -129,8 +129,8 @@
                         <div class="title">
                             <h1>Reactor Test</h1>
                             <div class="version">
-                                <span class="version releasetrain">Aluminium</span>
-                                <span class="version">3.0.4.RELEASE</span>
+                                <span class="version releasetrain hold">Aluminium-SR1</span>
+                                <span class="version">3.0.5.RELEASE</span>
                             </div>
                             <p>Test utilities</p>
                         </div>
@@ -149,8 +149,8 @@
                         <div class="title">
                             <h1>Reactor Adapter</h1>
                             <div class="version">
-                                <span class="version releasetrain">Aluminium</span>
-                                <span class="version">3.0.4.RELEASE</span>
+                                <span class="version releasetrain hold">Aluminium-SR1</span>
+                                <span class="version">3.0.5.RELEASE</span>
                             </div>
                             <p>Adapt to/from other Reactive libraries</p>
                         </div>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+  ~ Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -238,7 +238,7 @@
                 </div>
                 <div class="footer-content-text">
                     <span class="licence">Reactor regroups multiple open source projects licensed under the Apache Software License 2.</span>
-                    © 2013-2016 <a href="/">Reactor Project</a>, powered by
+                    © 2013-2017 <a href="/">Reactor Project</a>, powered by
                     <a href="http://pivotal.io/" class="pivotal">Pivotal</a> & <a href="http://spring.io/" class="spring">Spring</a>
                 </div>
             </footer>

--- a/src/main/resources/static/learn.html
+++ b/src/main/resources/static/learn.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+  ~ Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -187,7 +187,7 @@
                 </div>
                 <div class="footer-content-text">
                     <span class="licence">Reactor regroups multiple open source projects licensed under the Apache Software License 2.</span>
-                    © 2013-2016 <a href="/">Reactor Project</a>, powered by
+                    © 2013-2017 <a href="/">Reactor Project</a>, powered by
                     <a href="http://pivotal.io/" class="pivotal">Pivotal</a> & <a href="http://spring.io/" class="spring">Spring</a>
                 </div>
             </footer>

--- a/src/main/resources/static/project.html
+++ b/src/main/resources/static/project.html
@@ -94,8 +94,8 @@
                             A Reactive Streams foundation for Java 8
 
                             <div class="version">
-                                <span class="version releasetrain">Aluminium</span>
-                                <span class="version">3.0.4.RELEASE</span>
+                                <span class="version releasetrain">Aluminium-SR1</span>
+                                <span class="version">3.0.5.RELEASE</span>
                             </div>
                         </div>
                     </div>

--- a/src/main/resources/static/project.html
+++ b/src/main/resources/static/project.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+  ~ Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -242,7 +242,7 @@
                 </div>
                 <div class="footer-content-text">
                     <span class="licence">Reactor regroups multiple open source projects licensed under the Apache Software License 2.</span>
-                    © 2013-2016 <a href="/">Reactor Project</a>, powered by
+                    © 2013-2017 <a href="/">Reactor Project</a>, powered by
                     <a href="http://pivotal.io/" class="pivotal">Pivotal</a> & <a href="http://spring.io/"
                                                                                   class="spring">Spring</a>
                 </div>

--- a/src/main/resources/static/projects/index.html
+++ b/src/main/resources/static/projects/index.html
@@ -97,7 +97,7 @@
                             <span class="logo-reactor"></span>
                         </span>
                         <h1>Reactor BOM</h1>
-                        <span class="releasetrain">Aluminium</span>
+                        <span class="releasetrain">Aluminium-SR1</span>
                         <p>Release train <b>Aluminium</b></p>
                         <p>The <code>reactor-bom</code> project curates a list of Reactor
                             3 dependencies that go together. These are marked
@@ -118,7 +118,7 @@
                             <span class="logo-reactor"></span>
                         </span>
                         <h1>Reactor Core</h1>
-                        <span class="version">3.0.4.RELEASE</span>
+                        <span class="version">3.0.5.RELEASE</span>
                         <span class="releasetrain"><a title="Part of the release train">BOM</a></span>
                         <p>A Reactive Streams foundation for Java 8</p>
                         <p class="github">
@@ -133,7 +133,7 @@
                             <span class="logo-reactor"></span>
                         </span>
                         <h1>Reactor Test</h1>
-                        <span class="version">3.0.4.RELEASE</span>
+                        <span class="version">3.0.5.RELEASE</span>
                         <span class="releasetrain"><a title="Part of the release train">BOM</a></span>
                         <p>Test utilities<br/><br/></p>
                         <!--<a href="../test/docs/reference/" class="btn btn-primary">Read more</a>-->
@@ -149,7 +149,7 @@
                             <span class="logo-reactor"></span>
                         </span>
                         <h1>Reactor Adapter</h1>
-                        <span class="version">3.0.4.RELEASE</span>
+                        <span class="version">3.0.5.RELEASE</span>
                         <span class="releasetrain"><a title="Part of the release train">BOM</a></span>
                         <!--<a href="../adapter/docs/reference/" class="btn btn-primary">Read more</a>-->
                         <p>Adapt to/from other Reactive libraries</p>
@@ -169,7 +169,7 @@
                             <span class="fa fa-share-alt"></span>
                         </span>
                         <h1>Reactor Netty</h1>
-                        <span class="version">0.6.0.RELEASE</span>
+                        <span class="version">0.6.1.RELEASE</span>
                         <span class="releasetrain"><a title="Part of the release train">BOM</a></span>
                         <p>HTTP, TCP, UDP Client/Servers with Netty</p>
                         <!--<a href="../netty/docs/reference/" class="btn btn-primary">Read more</a>-->

--- a/src/main/resources/static/projects/index.html
+++ b/src/main/resources/static/projects/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+  ~ Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -304,7 +304,7 @@
         </div>
         <div class="footer-content-text">
             <span class="licence">Reactor regroups multiple open source projects licensed under the Apache Software License 2.</span>
-            © 2013-2016 <a href="/">Reactor Project</a>, powered by
+            © 2013-2017 <a href="/">Reactor Project</a>, powered by
             <a href="http://pivotal.io/" class="pivotal">Pivotal</a> & <a
                 href="http://spring.io/" class="spring">Spring</a>
         </div>

--- a/src/main/sass/_learn.scss
+++ b/src/main/sass/_learn.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/sass/_main.scss
+++ b/src/main/sass/_main.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/sass/_main.scss
+++ b/src/main/sass/_main.scss
@@ -47,6 +47,9 @@ span.version {
   line-height: 14px;
   &.releasetrain {
     background: $reactorPrimary;
+    &.hold {
+      background: darkorange;
+    }
   }
 }
 

--- a/src/main/sass/reactor.scss
+++ b/src/main/sass/reactor.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
For now, only `reactor-core 3.0.5` is linked (as it has been deployed in repo.spring.io), and the SR1 is hinted at but marqued as "progressively being released" in the docs header.

Also repo proxy the release/reference url.