### PR TITLE
M1 BOM released, milestone BOM differentiated

### DIFF
--- a/src/main/resources/modules.yml
+++ b/src/main/resources/modules.yml
@@ -49,20 +49,22 @@ name: netty
 groupId: io.projectreactor.ipc
 artifactId: reactor-netty
 versions:
+  - 0.6.3.RELEASE
   - 0.6.2.RELEASE
   - 0.6.1.RELEASE
   - 0.6.0.RELEASE
   - 0.5.2.RELEASE
-  - 0.6.3.BUILD-SNAPSHOT
+  - 0.6.4.BUILD-SNAPSHOT
 ---
 name: ipc
 groupId: io.projectreactor.ipc
 artifactId: reactor-ipc
 versions:
+  - 0.6.2.RELEASE
   - 0.6.1.RELEASE
   - 0.6.0.RELEASE
   - 0.5.1.RELEASE
-  - 0.6.2.BUILD-SNAPSHOT
+  - 0.6.3.BUILD-SNAPSHOT
 ---
 name: kafka
 groupId: io.projectreactor.kafka

--- a/src/main/resources/modules.yml
+++ b/src/main/resources/modules.yml
@@ -9,6 +9,7 @@ versions:
   - 3.0.4.RELEASE
   - 3.0.3.RELEASE
   - 3.1.0.BUILD-SNAPSHOT
+  - 3.1.0.M1
 ---
 name: test
 groupId: io.projectreactor.addons
@@ -20,6 +21,8 @@ versions:
   - 3.0.4.RELEASE
   - 3.0.3.RELEASE
   - 3.1.0.BUILD-SNAPSHOT
+  - 3.1.0.M1
+
 ---
 name: adapter
 groupId: io.projectreactor.addons
@@ -31,6 +34,7 @@ versions:
   - 3.0.4.RELEASE
   - 3.0.3.RELEASE
   - 3.1.0.BUILD-SNAPSHOT
+  - 3.1.0.M1
 ---
 name: extra
 groupId: io.projectreactor.addons
@@ -39,6 +43,7 @@ versions:
   - 3.0.7.RELEASE
   - 3.0.6.RELEASE
   - 3.1.0.BUILD-SNAPSHOT
+  - 3.1.0.M1
 ---
 name: netty
 groupId: io.projectreactor.ipc
@@ -63,5 +68,6 @@ name: kafka
 groupId: io.projectreactor.kafka
 artifactId: reactor-kafka
 versions:
+  - 1.0.0.M2
   - 1.0.0.M1
   - 1.0.0.BUILD-SNAPSHOT

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -92,8 +92,10 @@
                         <h1>Documentation</h1>
                         <div class="details">
                         <span id="author" class="author">Project Reactor reference
-                            documentation, code samples, and Javadoc.</span>
-                    </div>
+                            documentation, code samples, and Javadoc. See color coding legend at end</span>
+                        </div>
+                        Latest stable BOM: <span class="version releasetrain" title="Stable release train"> Aluminium-SR2</span><br/>
+                        Latest pre-release BOM:<span class="version releasetrain pre" title="MILESTONE release train"> Bismuth-M1</span>
                     </div>
                 </div>
             </div>
@@ -115,11 +117,11 @@
                                         <td>Release Train</td>
                                     </tr>
                                     <tr>
-                                        <td><span class="version pre" title="Latest MILESTONE"> 3.1.0.M1</span></a></td>
+                                        <td><span class="version pre" title="Latest Pre-Release"> 3.1.0.M1</span></a></td>
                                         <td><a href="https://github.com/reactor/reactor-core/releases/tag/v3.1.0.M1"
                                                title="See the reactor-core 3.1.0 MILESTONE 1 release notes on GitHub"
                                                class="fa fa-file-text">&nbsp;</a></td>
-                                        <td><span class="version releasetrain hold" title="Upcoming release train: Bismuth-M1"> Bismuth-M1</span></td>
+                                        <td><span class="version releasetrain pre" title="MILESTONE release train"> Bismuth-M1</span></td>
                                     </tr>
                                     <tr>
                                         <td><span class="version" title="Latest RELEASE">3.0.7.RELEASE</span></a></td>
@@ -172,11 +174,11 @@
                                         <td>Release Train</td>
                                     </tr>
                                     <tr>
-                                        <td><span class="version pre" title="Latest MILESTONE">3.1.0.M1</span></td>
+                                        <td><span class="version pre" title="Latest Pre-Release">3.1.0.M1</span></td>
                                         <td><a href="https://github.com/reactor/reactor-addons/releases/tag/v3.1.0.M1"
                                                title="See the reactor-addons 3.1.0 MILESTONE 1 release notes on GitHub"
                                                class="fa fa-file-text">&nbsp;</a></td>
-                                        <td><span class="version releasetrain hold" title="Upcoming release train"> Bismuth-M1</span></td>
+                                        <td><span class="version releasetrain pre" title="MILESTONE release train"> Bismuth-M1</span></td>
                                     </tr>
                                     <tr>
                                         <td><span class="version" title="Latest RELEASE">3.0.7.RELEASE</span></td>
@@ -228,11 +230,11 @@
                                         <td>Release Train</td>
                                     </tr>
                                     <tr>
-                                        <td><span class="version pre" title="Latest MILESTONE">3.1.0.M1</span></td>
+                                        <td><span class="version pre" title="Latest Pre-Release">3.1.0.M1</span></td>
                                         <td><a href="https://github.com/reactor/reactor-addons/releases/tag/v3.1.0.M1"
                                                title="See the reactor-addons 3.1.0 MILESTONE 1 release notes on GitHub"
                                                class="fa fa-file-text">&nbsp;</a></td>
-                                        <td><span class="version releasetrain hold" title="Upcoming release train"> Bismuth-M1</span></td>
+                                        <td><span class="version releasetrain pre" title="MILESTONE release train"> Bismuth-M1</span></td>
                                     </tr>
                                     <tr>
                                         <td><span class="version" title="Latest RELEASE">3.0.7.RELEASE</span></td>
@@ -279,12 +281,15 @@
                                         <td>Release Train</td>
                                     </tr>
                                     <tr>
-                                        <td><span class="version">0.6.2.RELEASE</span></td>
-                                        <td><a href="https://github.com/reactor/reactor-netty/releases/tag/v0.6.2.RELEASE"
+                                        <td><span class="version">0.6.3.RELEASE</span></td>
+                                        <td><a href="https://github.com/reactor/reactor-netty/releases/tag/v0.6.3.RELEASE"
                                                title="See the reactor-netty release notes on GitHub"
                                                class="fa fa-file-text">&nbsp;</a>
                                         </td>
-                                        <td><span class="version releasetrain">Aluminium-SR2</span></td>
+                                        <td>
+                                            <span class="version releasetrain pre" title="Part of the latest MILESTONE release train">Bismuth-M1</span><br/>
+                                            <span class="version releasetrain" title="Part of the latest stable release train">Aluminium-SR2</span>
+                                        </td>
                                     </tr>
                                 </table>
                             </div>
@@ -316,11 +321,11 @@
                                         <td>Release Train</td>
                                     </tr>
                                     <tr>
-                                        <td><span class="version pre" title="Latest MILESTONE">3.1.0.M1</span></td>
+                                        <td><span class="version pre" title="Latest Pre-Release">3.1.0.M1</span></td>
                                         <td><a href="https://github.com/reactor/reactor-addons/releases/tag/v3.1.0.M1"
                                                title="See the reactor-addons 3.1.0 MILESTONE 1 release notes on GitHub"
                                                class="fa fa-file-text">&nbsp;</a></td>
-                                        <td><span class="version releasetrain hold" title="Upcoming release train"> Bismuth-M1</span></td>
+                                        <td><span class="version releasetrain pre" title="MILESTONE release train"> Bismuth-M1</span></td>
                                     </tr>
                                     <tr>
                                         <td><span class="version" title="Latest RELEASE">3.0.7.RELEASE</span></td>
@@ -358,8 +363,23 @@
                             <h1>Reactor Kafka</h1>
                             <p>Reactive bridge to Apache Kafka</p>
                             <div class="version">
-                                <span class="version">1.0.0.M1</span>
-                                <!--<span class="version releasetrain">Aluminium</span>-->
+                                <table>
+                                    <tr><td>Version</td>
+                                        <td><a href="http://github.com/reactor/reactor-kafka/releases"
+                                               title="See all reactor-kafka releases on GitHub"
+                                               class="fa fa-archive">&nbsp;</a>
+                                        </td>
+                                        <td>Release Train</td>
+                                    </tr>
+                                    <tr>
+                                        <td><span class="version pre" title="Latest Pre-Release">1.0.0.M2</span></td>
+                                        <td><a href="https://github.com/reactor/reactor-kafka/releases/tag/v1.0.0.M2"
+                                               title="See the reactor-kafka release notes on GitHub"
+                                               class="fa fa-file-text">&nbsp;</a>
+                                        </td>
+                                        <td><span class="version releasetrain pre" title="MILESTONE release train">Bismuth-M1</span></td>
+                                    </tr>
+                                </table>
                             </div>
                         </div>
                         <div class="github">
@@ -422,9 +442,12 @@
                         <li><span class="version releasetrain">RELEASE-TRAIN</span>: Artifact participating in the latest stable
                             and fully available release train (<span class="version releasetrain">Aluminium-SR2</span>).
                         </li>
+                        <li><span class="version releasetrain pre">RELEASE-TRAIN</span>: Artifact participating in the latest
+                            pre-release release train (<span class="version releasetrain pre">Bismuth-M1</span>).
+                        </li>
                         <li><span class="version releasetrain hold">RELEASE-TRAIN</span>: Artifacts participating in these
                             release trains have not all been released, so the BOMs are not available yet (
-                            <span class="version releasetrain hold">Aluminium-SR3</span>, <span class="version releasetrain hold">Bismuth-M1</span>).
+                            <span class="version releasetrain hold">Aluminium-SR3</span>).
                         </li>
                         <li><span class="version">version</span>: Available RELEASE artifact.</li>
                         <li><span class="version pre">version</span>: Available MILESTONE or other pre-release artifact (on repo.spring.io).</li>

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -288,6 +288,16 @@
                                         </td>
                                         <td>
                                             <span class="version releasetrain pre" title="Part of the latest MILESTONE release train">Bismuth-M1</span><br/>
+                                            <span class="version releasetrain hold" title="Part of an upcoming release train">Aluminium-SR3</span>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td><span class="version">0.6.2.RELEASE</span></td>
+                                        <td><a href="https://github.com/reactor/reactor-netty/releases/tag/v0.6.2.RELEASE"
+                                               title="See the reactor-netty release notes on GitHub"
+                                               class="fa fa-file-text">&nbsp;</a>
+                                        </td>
+                                        <td>
                                             <span class="version releasetrain" title="Part of the latest stable release train">Aluminium-SR2</span>
                                         </td>
                                     </tr>

--- a/src/main/sass/_main.scss
+++ b/src/main/sass/_main.scss
@@ -47,6 +47,11 @@ span.version {
   line-height: 14px;
   &.releasetrain {
     background: $reactorTextColor;
+    &.pre {
+      background: linear-gradient(135deg,
+              $reactorTextColor 0%,$reactorTextColor 80%,
+              darkorange 81%,darkorange 100%);
+    }
     &.hold {
       background: darkgrey;
     }


### PR DESCRIPTION
I added color coding for release trains of pre-releases like M1, has
a small corner in orange.