### PR TITLE
Fix link to Akka docs to be to current version

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -160,7 +160,7 @@
                                 As a Reactive Engine/SPI, both Reactor Core and IO modules expose reactive streams
                                 constructs for focused
                                 use cases, eventually combined with <a href="http://spring.io">Spring</a>, <a href="http://reactivex.io">
-                                RxJava</a>, <a href="http://doc.akka.io/docs/akka-stream-and-http-experimental/current/java.html">Akka
+                                RxJava</a>, <a href="https://doc.akka.io/docs/akka/current/?language=java">Akka
                                 Streams</a>, <a href="http://ratpack.io">Ratpack</a>... As a Reactive API, reactor
                                 framework modules will offer rich consumable features like
                                 composition and pub-sub eventing.


### PR DESCRIPTION
Thanks for including the link on the site!
Wanted to update it since it was linking to a very old version while the module was still experimental :-)

Thanks in advance