### PR TITLE
fix #22 Move the deck in a dedicated row

### DIFF
--- a/src/main/resources/static/templates/learn.html
+++ b/src/main/resources/static/templates/learn.html
@@ -22,11 +22,13 @@
     <div class="learn">
         <div class="project">
             <div class="project-row">
+                <div class="book">
+                    <section><script async class="speakerdeck-embed" data-id="fa5195b61d9e4d7bb85c84fc53740b89" data-ratio="1.5" src="//speakerdeck.com/assets/embed.js"></script></section>
+                </div>
+            </div>
+            <div class="project-row">
                 <div class="project-col-left">
-
-
                     <div class="book">
-                        <section><script async class="speakerdeck-embed" data-id="fa5195b61d9e4d7bb85c84fc53740b89" data-ratio="1.77777777777778" src="//speakerdeck.com/assets/embed.js"></script></section>
                         <section id="learn-curated">
                             <article>
                                 <p class="title"><span class="fa fa-github">&nbsp;</span>


### PR DESCRIPTION
Avoids the tweet block going over the deck by putting it next to shorter
link blocks, resulting in the deck being in a single column.