### PR TITLE
fixes case of version string on documentation

### DIFF
--- a/src/main/sass/_main.scss
+++ b/src/main/sass/_main.scss
@@ -41,7 +41,6 @@ span.version {
   color: white;
   border-radius: 3px;
   font-size: 11px;
-  text-transform: uppercase;
   font-weight: bold;
   padding: 2Px 4px 2px;
   line-height: 14px;


### PR DESCRIPTION
I was copying the version string from 

"Latest stable BOM: CALIFORNIUM-SR4"

and needed 15minutes to find out the version is not upper case.

It should be "Latest stable BOM: Californium-SR4"