### PR TITLE
Fix resource location resolve error when running shadowJar

### DIFF
--- a/src/main/java/io/projectreactor/Application.java
+++ b/src/main/java/io/projectreactor/Application.java
@@ -266,7 +266,7 @@ public final class Application {
 				//ignore
 			}
 		}));
-		return fs.getPath("BOOT-INF/classes/static");
+		return fs.getPath("static");
 	}
 
 


### PR DESCRIPTION
**Repair resource location resolve error when running standalone jar**
While running standalone jar ,  the browser report **404 not found** and **no style** applied . Because wrong configuration.