### PR TITLE
fix #42 Kotlin Doc rework after Dysprosium-RELEASE issues

### DIFF
--- a/src/main/java/io/projectreactor/DocUtils.java
+++ b/src/main/java/io/projectreactor/DocUtils.java
@@ -126,27 +126,22 @@ public class DocUtils {
 	}
 
 	static boolean isKDocSpecialCases(String module, String version) {
-		if (("core".equals(module)
-				|| "extra".equals(module)
-				|| "test".equals(module)
-		)
-				&& !version.startsWith("3.0")
-				&& !version.startsWith("3.1")
-				&& !version.startsWith("3.2")) {
-			//core/addons/test >= Dysprosium
-			return true;
-		}
-		//reactor-kotlin-extensions Dysprosium
-		if ("kotlin".equals(module)) {
-			//exception for 1.0.0 pre-releases
-			if (version.startsWith("1.0.0") && !version.equals("1.0.0.RELEASE")) {
+		switch (module) {
+			case "core":
+			case "extra":
+			case "test":
+				//core/addons/test >= Dysprosium
+				return !version.startsWith("3.0")
+						&& !version.startsWith("3.1")
+						&& !version.startsWith("3.2");
+			case "kotlin":
+				//exception for 1.0.0 pre-releases
+				//for now all kotlin >= 1.0.0.RELEASE have no kdoc
+				//TODO restrict to a version range when kdoc are eventually generated
+				return version.equals("1.0.0.RELEASE") || !version.startsWith("1.0.0");
+			default:
 				return false;
-			}
-			//for now all kotlin >= 1.0.0.RELEASE have no kdoc
-			//TODO restrict to a version range when kdoc are eventually generated
-			return true;
 		}
-		return false;
 	}
 
 	static String moduleToKdocUrl(String reqUri, String versionType,

--- a/src/main/java/io/projectreactor/DocUtils.java
+++ b/src/main/java/io/projectreactor/DocUtils.java
@@ -110,6 +110,9 @@ public class DocUtils {
 					12, "index.html", "-javadoc.jar", "", "");
 		}
 		else if (reqUri.contains("/kdoc-api/")) {
+			if (isKDocSpecialCases(actualModule.getName(), actualVersion)) {
+				return WARNING_NO_KDOC + actualModule.getArtifactId() + ":" + actualVersion;
+			}
 			url = moduleToKdocUrl(reqUri, versionType, requestedModuleName,
 					requestedVersion, actualModule, actualVersion);
 		}
@@ -120,6 +123,30 @@ public class DocUtils {
 					"docs/");
 		}
 		return url;
+	}
+
+	static boolean isKDocSpecialCases(String module, String version) {
+		if (("core".equals(module)
+				|| "extra".equals(module)
+				|| "test".equals(module)
+		)
+				&& !version.startsWith("3.0")
+				&& !version.startsWith("3.1")
+				&& !version.startsWith("3.2")) {
+			//core/addons/test >= Dysprosium
+			return true;
+		}
+		//reactor-kotlin-extensions Dysprosium
+		if ("kotlin".equals(module)) {
+			//exception for 1.0.0 pre-releases
+			if (version.startsWith("1.0.0") && !version.equals("1.0.0.RELEASE")) {
+				return false;
+			}
+			//for now all kotlin >= 1.0.0.RELEASE have no kdoc
+			//TODO restrict to a version range when kdoc are eventually generated
+			return true;
+		}
+		return false;
 	}
 
 	static String moduleToKdocUrl(String reqUri, String versionType,
@@ -173,4 +200,8 @@ public class DocUtils {
 		return url;
 	}
 
+	/**
+	 * static 404 we send to when a KDoc is requested for a special project+version combination that doesn't have them
+	 */
+	public static final String WARNING_NO_KDOC = "warningNoKDoc:";
 }

--- a/src/main/resources/static/templates/404NoKDoc.html
+++ b/src/main/resources/static/templates/404NoKDoc.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html th:replace="~{layout :: layout('404', ~{::title}, ~{::meta[@name='description']}, ~{::link}, ~{::body})}" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Project Reactor - 404 No Kotlin Doc Available</title>
+    <meta name="description" content="404 No Kotlin Doc Available" />
+    <link href="/assets/css/docs.css" media="all" rel="stylesheet"/>
+</head>
+<body>
+
+<div class="content" id="content">
+    <section class="page404">
+        <img height="145px" src="/assets/img/404.jpg" />
+        <h1>The artifact and version you requested doesn't have Kotlin Doc.</h1>
+        <article>
+            <p class="desc">
+                You tried to access Kotlin Doc through <span class="version pre" th:text="${requestedPage}">PAGE PLACEHOLDER</span>.
+                <br/>Component <span class="version pre" th:text="${actualModule}">COMPONENT PLACEHOLDER</span>
+                and version <span class="version pre" th:text="${actualVersion}">VERSION PLACEHOLDER</span>
+            </p>
+            <p class="desc">
+                This combination doesn't have Kotlin Docs, because it belongs to one of the cases below:
+            <br/>
+            <table>
+            <tr>
+                <td>
+                <code>reactor-core</code> and <code>reactor-extra</code>, 3.3.0+ (Dysprosium and above)
+                </td>
+                <td>
+                The Kotlin extensions have been moved to <code>reactor-kotlin-extensions</code>
+                (see below)
+                </td>
+            </tr>
+            <tr>
+                <td>
+                <code>reactor-kotlin-extension</code> from version <code>1.0.0.RELEASE</code>
+                to version <code>to be determined</code>
+                </td>
+                <td>
+                A blocking bug in the dokka tooling prevents us from publishing kdoc and javadoc,
+                and we HAVE to publish javadocs on Maven Central.
+                <br/>
+                You can try to access javadocs instead (replace <code>kdoc-api</code> with <code>api</code>
+                in the <strong>original</strong> URL you tried to access).
+                </td>
+            </tr>
+            </table>
+            </p>
+            <p class="desc">
+                You can also find some helpful links in the footer below, or try a page from the navigation bar on top...
+                <br/>If you think this URL should have worked, please open an
+                <a href="https://github.com/reactor/projectreactor.io/issues">issue</a>.
+            </p>
+        </article>
+    </section>
+</div>
+
+</body>
+</html>

--- a/src/main/resources/static/templates/docs.html
+++ b/src/main/resources/static/templates/docs.html
@@ -144,7 +144,7 @@
                 <a href="/docs/core/release/api/">Release</a> |
                 <span th:if="${milestone.coreVersion} != null"><a href="/docs/core/milestone/api/">Milestone</a> |</span>
                 <a href="/docs/core/snapshot/api/">Snapshot</a> |
-                <a href="/docs/core/release/kdoc-api/">Kotlin Doc</a>
+<!--                <a href="/docs/core/release/kdoc-api/">Kotlin Doc</a>-->
             </div>
             <div class="reference">
                 <strong>Reference</strong><br />
@@ -245,7 +245,7 @@
                 <a href="/docs/test/release/api/">Release</a> |
                 <span th:if="${milestone.testVersion} != null"><a href="/docs/test/milestone/api/">Milestone</a> |</span>
                 <a href="/docs/test/snapshot/api/">Snapshot</a> |
-                <a href="/docs/test/release/kdoc-api/">Kotlin Doc</a>
+<!--                <a href="/docs/test/release/kdoc-api/">Kotlin Doc</a>-->
 
             </div>
             <div class="reference">
@@ -702,11 +702,17 @@
                     Github
                 </a>
             </div>
+<!--            <div class="javadoc">-->
+<!--                <strong>Kotlin Doc</strong><br />-->
+<!--                <a href="/docs/kotlin/release/kdoc-api/">Release</a> |-->
+<!--                <span th:if="${milestone.kotlinVersion} != null"><a href="/docs/kotlin/milestone/kdoc-api/">Milestone</a> |</span>-->
+<!--                <a href="/docs/kotlin/snapshot/kdoc-api/">Snapshot</a>-->
+<!--            </div>-->
             <div class="javadoc">
-                <strong>Kotlin Doc</strong><br />
-                <a href="/docs/kotlin/release/kdoc-api/">Release</a> |
-                <span th:if="${milestone.kotlinVersion} != null"><a href="/docs/kotlin/milestone/kdoc-api/">Milestone</a> |</span>
-                <a href="/docs/kotlin/snapshot/kdoc-api/">Snapshot</a>
+                <strong>Javadoc (temporarily instead of Kotlin Doc)</strong><br />
+                <a href="/docs/kotlin/release/api/">Release</a> |
+                <span th:if="${milestone.kotlinVersion} != null"><a href="/docs/kotlin/milestone/api/">Milestone</a> |</span>
+                <a href="/docs/kotlin/snapshot/api/">Snapshot</a>
             </div>
             <div class="reference">
                 <strong>Reference</strong> <br/>

--- a/src/test/java/io/projectreactor/DocUtilsTest.java
+++ b/src/test/java/io/projectreactor/DocUtilsTest.java
@@ -1,11 +1,11 @@
 package io.projectreactor;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
+
 import reactor.util.function.Tuple2;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -421,6 +421,94 @@ public class DocUtilsTest {
 	@Test
 	public void checkModuleVersionReleaseCandidateIsMilestone() {
 		assertThat(DocUtils.checkModuleVersion("3.1.0.RC2", "MILESTONE")).isTrue();
+	}
+
+	@Test
+	public void coreCaliforniumAndBelowIsNotKotlinDocSpecial() {
+		assertThat(DocUtils.isKDocSpecialCases("core", "3.0.0"))
+				.as("3.0.0").isFalse();
+		assertThat(DocUtils.isKDocSpecialCases("core", "3.1.0"))
+				.as("3.1.0").isFalse();
+		assertThat(DocUtils.isKDocSpecialCases("core", "3.2.0"))
+				.as("3.2.0").isFalse();
+	}
+
+	@Test
+	public void coreDysprosiumAndAboveIsKotlinDocSpecial() {
+		assertThat(DocUtils.isKDocSpecialCases("core", "3.3.0.M1"))
+				.as("3.0.0.M1").isTrue();
+		assertThat(DocUtils.isKDocSpecialCases("core", "3.3.1.RELEASE"))
+				.as("3.3.1.RELEASE").isTrue();
+		assertThat(DocUtils.isKDocSpecialCases("core", "3.4.0.x"))
+				.as("3.4.0.x").isTrue();
+		assertThat(DocUtils.isKDocSpecialCases("core", "3.6.1.BUILD-SNAPSHOT"))
+				.as("3.6.1.BUILD-SNAPSHOT").isTrue();
+	}
+
+	@Test
+	public void extraCaliforniumAndBelowIsNotIsKotlinDocSpecial() {
+		assertThat(DocUtils.isKDocSpecialCases("extra", "3.0.0"))
+				.as("3.0.0").isFalse();
+		assertThat(DocUtils.isKDocSpecialCases("extra", "3.1.0"))
+				.as("3.1.0").isFalse();
+		assertThat(DocUtils.isKDocSpecialCases("extra", "3.2.0"))
+				.as("3.2.0").isFalse();
+	}
+
+	@Test
+	public void extraDysprosiumAndAboveIsKotlinDocSpecial() {
+		assertThat(DocUtils.isKDocSpecialCases("extra", "3.3.0.M1"))
+				.as("3.0.0.M1").isTrue();
+		assertThat(DocUtils.isKDocSpecialCases("extra", "3.3.1.RELEASE"))
+				.as("3.3.1.RELEASE").isTrue();
+		assertThat(DocUtils.isKDocSpecialCases("extra", "3.4.0.x"))
+				.as("3.4.0.x").isTrue();
+		assertThat(DocUtils.isKDocSpecialCases("extra", "3.6.1.BUILD-SNAPSHOT"))
+				.as("3.6.1.BUILD-SNAPSHOT").isTrue();
+	}
+
+	@Test
+	public void testCaliforniumAndBelowIsNotKotlinDocSpecial() {
+		assertThat(DocUtils.isKDocSpecialCases("test", "3.0.0"))
+				.as("3.0.0").isFalse();
+		assertThat(DocUtils.isKDocSpecialCases("test", "3.1.0"))
+				.as("3.1.0").isFalse();
+		assertThat(DocUtils.isKDocSpecialCases("test", "3.2.0"))
+				.as("3.2.0").isFalse();
+	}
+
+	@Test
+	public void testDysprosiumAndAboveIsKotlinDocSpecial() {
+		assertThat(DocUtils.isKDocSpecialCases("test", "3.3.0.M1"))
+				.as("3.0.0.M1").isTrue();
+		assertThat(DocUtils.isKDocSpecialCases("test", "3.3.1.RELEASE"))
+				.as("3.3.1.RELEASE").isTrue();
+		assertThat(DocUtils.isKDocSpecialCases("test", "3.4.0.x"))
+				.as("3.4.0.x").isTrue();
+		assertThat(DocUtils.isKDocSpecialCases("test", "3.6.1.BUILD-SNAPSHOT"))
+				.as("3.6.1.BUILD-SNAPSHOT").isTrue();
+	}
+
+	@Test
+	public void kotlinExtensionsDysprosiumReleaseAndAboveIsKotlinDocSpecial() {
+		assertThat(DocUtils.isKDocSpecialCases("kotlin", "1.0.0.RELEASE"))
+				.as("1.0.0.RELEASE").isTrue();
+		assertThat(DocUtils.isKDocSpecialCases("kotlin", "1.0.1.BUILD-SNAPSHOT"))
+				.as("1.0.1.BUILD-SNAPSHOT").isTrue();
+		assertThat(DocUtils.isKDocSpecialCases("kotlin", "1.0.1.M1"))
+				.as("1.0.1.M1").isTrue();
+		assertThat(DocUtils.isKDocSpecialCases("kotlin", "1.0.1.RC1"))
+				.as("1.0.1.RC1").isTrue();
+	}
+
+	@Test
+	public void kotlinExtensionsDysprosiumPreReleasesAreNotKotlinDocSpecial() {
+		assertThat(DocUtils.isKDocSpecialCases("kotlin", "1.0.0.BUILD-SNAPSHOT"))
+				.as("1.0.0.BUILD-SNAPSHOT").isFalse();
+		assertThat(DocUtils.isKDocSpecialCases("kotlin", "1.0.0.M1"))
+				.as("1.0.0.M1").isFalse();
+		assertThat(DocUtils.isKDocSpecialCases("kotlin", "1.0.0.RC1"))
+				.as("1.0.0.RC1").isFalse();
 	}
 
 }


### PR DESCRIPTION
 - Removed the Kotlin Doc link from core and test sections
 - Replaced the Kotlin Doc link in kotlin-extensions section with
 javadoc link (see reactor/reactor-kotlin-extensions#3)
 - DocUtils takes these restrictions into account and we now redirect
 to a special 404 page to explain the situation, should one directly
 request a bad kdoc-api link