### PR TITLE
Add EOL badge markers, poolish CSS for versions

### DIFF
--- a/src/main/resources/modules.yml
+++ b/src/main/resources/modules.yml
@@ -7,6 +7,8 @@ artifactId: reactor-bom
 versions:
   - Dysprosium-SR13
   - Californium-SR22
+#badVersions is used as placeholder for release trains that hit EoL
+badVersions:
   - Bismuth-SR17
   - Aluminium-SR3
 ---

--- a/src/main/resources/static/templates/docs.html
+++ b/src/main/resources/static/templates/docs.html
@@ -30,23 +30,26 @@
                             documentation and Javadoc. </span>
             <div class="details">
                 <div th:if="${upcoming.name} != null">
-                    Upcoming BOM: <span class="version releasetrain hold"
-                                        title="Partially available release train"
-                                        th:text="${upcoming.name}">UPCOMING</span><br/>
+                    Upcoming BOM:
+                    <span th:if="${upcoming.codename} == null" class="version releasetrain partial" title="Partially available release train" th:text="${upcoming.name}">UPCOMING</span><br/>
+                    <span th:if="${upcoming.codename} != null" class="version releasetrain partial" title="Partially available release train" th:text="${upcoming.name + ' (' + upcoming.codename + ')'}">STABLE_WITH_CODENAME</span><br/>
                 </div>
             </div>
             Latest stable BOM:
             <span th:if="${stable.codename} == null" class="version releasetrain" title="Stable release train" th:text="${stable.name}">STABLE</span>
-            <span th:if="${stable.codename} != null" class="version releasetrain" title="Stable release train" th:text="${stable.name + ' (codename ' + stable.codename + ')'}">STABLE_WITH_CODENAME</span>            <br/>
+            <span th:if="${stable.codename} != null" class="version releasetrain" title="Stable release train" th:text="${stable.name + ' (' + stable.codename + ')'}">STABLE_WITH_CODENAME</span>            <br/>
             <div th:if="${milestone.name} != null">
                 Latest pre-release BOM:
                 <span th:if="${milestone.codename} == null" class="version releasetrain pre" title="MILESTONE release train" th:text="${milestone.name}">MILESTONE</span>
-                <span th:if="${milestone.codename} != null" class="version releasetrain pre" title="MILESTONE release train" th:text="${milestone.name + ' (codename ' + milestone.codename + ')'}">MILESTONE_WITH_CODENAME</span>
+                <span th:if="${milestone.codename} != null" class="version releasetrain pre" title="MILESTONE release train" th:text="${milestone.name + ' (' + milestone.codename + ')'}">MILESTONE_WITH_CODENAME</span>
             </div>
-            <div th:if="${oldBoms.versions} != null">
+            <div>
                 Latest BOMs in previous release trains:
-                <span th:each="bom : ${oldBoms.versions}">
-                    <span class="version releasetrain hold" th:text="${bom}">OLD BOM</span>&nbsp;
+                <span th:if="${oldBoms.versions} != null" th:each="bom : ${oldBoms.versions}">
+                    <span class="version releasetrain maintenance" th:text="${bom}">OLD BOM</span>&nbsp;
+                </span>
+                <span th:if="${oldBoms.badVersions} != null" th:each="bom : ${oldBoms.badVersions}">
+                    <span class="version releasetrain eol" th:text="${bom}">EOL BOM</span>&nbsp;
                 </span>
             </div>
         </div>
@@ -74,7 +77,6 @@
                         <tr th:if="${upcoming.coreVersion} != null">
                             <td>
                                     <span class="version"
-                                          th:classappend="${!#strings.endsWith(upcoming.coreVersion,'.RELEASE')}? 'pre'"
                                           title="Latest Release In Incomplete BOM"
                                           th:text="${upcoming.coreVersion}">VERSION</span>
                             </td>
@@ -85,7 +87,7 @@
                                    class="fa fa-file-text">&nbsp;</a>
                             </td>
                             <td>
-                                    <span class="version releasetrain hold"
+                                    <span class="version releasetrain partial"
                                           title="Partially available release train"
                                           th:text="${upcoming.name}"> BOM</span>
                             </td>
@@ -192,7 +194,6 @@
                         <tr th:if="${upcoming.testVersion} != null">
                             <td>
                                     <span class="version"
-                                          th:classappend="${!#strings.endsWith(upcoming.testVersion,'.RELEASE')}? 'pre'"
                                           title="Latest Release In Incomplete BOM"
                                           th:text="${upcoming.testVersion}">VERSION</span>
                             </td>
@@ -203,7 +204,7 @@
                                    class="fa fa-file-text">&nbsp;</a>
                             </td>
                             <td>
-                                    <span class="version releasetrain hold"
+                                    <span class="version releasetrain partial"
                                           title="Partially available release train"
                                           th:text="${upcoming.name}"> BOM</span>
                             </td>
@@ -307,7 +308,6 @@
                         <tr th:if="${upcoming.extraVersion} != null">
                             <td>
                                     <span class="version"
-                                          th:classappend="${!#strings.endsWith(upcoming.extraVersion,'.RELEASE')}? 'pre'"
                                           title="Latest Release In Incomplete BOM"
                                           th:text="${upcoming.extraVersion}">VERSION</span>
                             </td>
@@ -318,7 +318,7 @@
                                    class="fa fa-file-text">&nbsp;</a>
                             </td>
                             <td>
-                                    <span class="version releasetrain hold"
+                                    <span class="version releasetrain partial"
                                           title="Partially available release train"
                                           th:text="${upcoming.name}"> BOM</span>
                             </td>
@@ -412,7 +412,6 @@
                         <tr th:if="${upcoming.nettyVersion} != null">
                             <td>
                                     <span class="version"
-                                          th:classappend="${!#strings.endsWith(upcoming.nettyVersion,'.RELEASE')}? 'pre'"
                                           title="Latest Release In Incomplete BOM"
                                           th:text="${upcoming.nettyVersion}">VERSION</span>
                             </td>
@@ -423,7 +422,7 @@
                                    class="fa fa-file-text">&nbsp;</a>
                             </td>
                             <td>
-                                    <span class="version releasetrain hold"
+                                    <span class="version releasetrain partial"
                                           title="Partially available release train"
                                           th:text="${upcoming.name}"> BOM</span>
                             </td>
@@ -522,7 +521,6 @@
                         <tr th:if="${upcoming.adapterVersion} != null">
                             <td>
                                     <span class="version"
-                                          th:classappend="${!#strings.endsWith(upcoming.adapterVersion,'.RELEASE')}? 'pre'"
                                           title="Latest Release In Incomplete BOM"
                                           th:text="${upcoming.adapterVersion}">VERSION</span>
                             </td>
@@ -533,7 +531,7 @@
                                    class="fa fa-file-text">&nbsp;</a>
                             </td>
                             <td>
-                                    <span class="version releasetrain hold"
+                                    <span class="version releasetrain partial"
                                           title="Partially available release train"
                                           th:text="${upcoming.name}"> BOM</span>
                             </td>
@@ -625,7 +623,6 @@
                         <tr th:if="${upcoming.kafkaVersion} != null">
                             <td>
                                     <span class="version"
-                                          th:classappend="${!#strings.endsWith(upcoming.kafkaVersion,'.RELEASE')}? 'pre'"
                                           title="Latest Release In Incomplete BOM"
                                           th:text="${upcoming.kafkaVersion}">VERSION</span>
                             </td>
@@ -636,7 +633,7 @@
                                    class="fa fa-file-text">&nbsp;</a>
                             </td>
                             <td>
-                                    <span class="version releasetrain hold"
+                                    <span class="version releasetrain partial"
                                           title="Partially available release train"
                                           th:text="${upcoming.name}"> BOM</span>
                             </td>
@@ -733,7 +730,6 @@
                         <tr th:if="${upcoming.kotlinVersion} != null">
                             <td>
                                     <span class="version"
-                                          th:classappend="${!#strings.endsWith(upcoming.kotlinVersion,'.RELEASE')}? 'pre'"
                                           title="Latest Release In Incomplete BOM"
                                           th:text="${upcoming.kotlinVersion}">VERSION</span>
                             </td>
@@ -744,7 +740,7 @@
                                    class="fa fa-file-text">&nbsp;</a>
                             </td>
                             <td>
-                                    <span class="version releasetrain hold"
+                                    <span class="version releasetrain partial"
                                           title="Partially available release train"
                                           th:text="${upcoming.name}"> BOM</span>
                             </td>
@@ -850,7 +846,6 @@
                         <tr th:if="${upcoming.rabbitVersion} != null">
                             <td>
                                     <span class="version"
-                                          th:classappend="${!#strings.endsWith(upcoming.rabbitVersion,'.RELEASE')}? 'pre'"
                                           title="Latest Release In Incomplete BOM"
                                           th:text="${upcoming.rabbitVersion}">VERSION</span>
                             </td>
@@ -862,7 +857,7 @@
                             </td>
                             <td>
                                     <span th:if="${upcoming.name} != null"
-				          class="version releasetrain hold"
+				          class="version releasetrain partial"
                                           title="Partially available release train"
                                           th:text="${upcoming.name}"> BOM</span>
                             </td>
@@ -963,7 +958,6 @@
                         <tr th:if="${upcoming.poolVersion} != null">
                             <td>
                                     <span class="version"
-                                          th:classappend="${!#strings.endsWith(upcoming.poolVersion,'.RELEASE')}? 'pre'"
                                           title="Latest Release In Incomplete BOM"
                                           th:text="${upcoming.poolVersion}">VERSION</span>
                             </td>
@@ -975,7 +969,7 @@
                             </td>
                             <td>
                                     <span th:if="${upcoming.name} != null"
-                                          class="version releasetrain hold"
+                                          class="version releasetrain partial"
                                           title="Partially available release train"
                                           th:text="${upcoming.name}"> BOM</span>
                             </td>
@@ -1120,7 +1114,7 @@
     <div class="details">
       <p>Legend:</p>
         <ul>
-            <li><span class="version releasetrain hold">RELEASE-TRAIN</span>: Artifacts in these release trains have not all been released (<span th:if="${upcoming.coreVersion} != null">currently <span class="version releasetrain hold" th:text="${upcoming.name}"> CURRENT</span></span><span th:if="${upcoming.coreVersion} == null">e.g. <span class="version releasetrain hold"> Californium-SR30</span></span>).  </li>
+            <li><span class="version releasetrain partial">RELEASE-TRAIN</span>: Artifacts in these release trains have not all been released (<span th:if="${upcoming.coreVersion} != null">currently <span class="version releasetrain partial" th:text="${upcoming.name}"> CURRENT</span></span><span th:if="${upcoming.coreVersion} == null">e.g. <span class="version releasetrain partial"> Californium-SR30</span></span>).  </li>
             <li><span class="version releasetrain">RELEASE-TRAIN</span>: Artifacts in the latest stable and fully available release train (<span th:if="${stable.coreVersion} != null">currently <span class="version releasetrain" th:text="${stable.name}">CURRENT</span></span> <span th:if="${stable.coreVersion} == null">e.g. <span class="version releasetrain">Bismuth-SR10</span></span>).  </li>
             <li><span class="version releasetrain pre">RELEASE-TRAIN</span>: Artifacts in the latest pre-release release train (<span th:if="${milestone.coreVersion} != null">currently <span class="version releasetrain pre" th:text="${milestone.name}">CURRENT</span></span> <span th:if="${milestone.coreVersion} == null">e.g. <span class="version releasetrain pre">Californium-M1</span></span>).  </li>
             <li><span class="version">version</span>: Available RELEASE artifacts.</li>

--- a/src/main/resources/static/templates/docs.html
+++ b/src/main/resources/static/templates/docs.html
@@ -26,32 +26,33 @@
     <div class="page-summary-content">
         <div class="page-summary-wrap">
             <h1>Documentation</h1>
-            <span id="author" class="author">Project Reactor reference
-                            documentation and Javadoc. </span>
-            <div class="details">
-                <div th:if="${upcoming.name} != null">
+            <span id="author" class="author">Project Reactor reference documentation and Javadoc. </span>
+            <ul>
+                <li th:if="${upcoming.name} != null">
                     Upcoming BOM:
-                    <span th:if="${upcoming.codename} == null" class="version releasetrain partial" title="Partially available release train" th:text="${upcoming.name}">UPCOMING</span><br/>
-                    <span th:if="${upcoming.codename} != null" class="version releasetrain partial" title="Partially available release train" th:text="${upcoming.name + ' (' + upcoming.codename + ')'}">STABLE_WITH_CODENAME</span><br/>
-                </div>
-            </div>
-            Latest stable BOM:
-            <span th:if="${stable.codename} == null" class="version releasetrain" title="Stable release train" th:text="${stable.name}">STABLE</span>
-            <span th:if="${stable.codename} != null" class="version releasetrain" title="Stable release train" th:text="${stable.name + ' (' + stable.codename + ')'}">STABLE_WITH_CODENAME</span>            <br/>
-            <div th:if="${milestone.name} != null">
-                Latest pre-release BOM:
-                <span th:if="${milestone.codename} == null" class="version releasetrain pre" title="MILESTONE release train" th:text="${milestone.name}">MILESTONE</span>
-                <span th:if="${milestone.codename} != null" class="version releasetrain pre" title="MILESTONE release train" th:text="${milestone.name + ' (' + milestone.codename + ')'}">MILESTONE_WITH_CODENAME</span>
-            </div>
-            <div>
-                Latest BOMs in previous release trains:
-                <span th:if="${oldBoms.versions} != null" th:each="bom : ${oldBoms.versions}">
-                    <span class="version releasetrain maintenance" th:text="${bom}">OLD BOM</span>&nbsp;
-                </span>
-                <span th:if="${oldBoms.badVersions} != null" th:each="bom : ${oldBoms.badVersions}">
-                    <span class="version releasetrain eol" th:text="${bom}">EOL BOM</span>&nbsp;
-                </span>
-            </div>
+                    <span th:if="${upcoming.codename} == null" class="version releasetrain partial" title="Partially available release train" th:text="${upcoming.name}">UPCOMING</span>
+                    <span th:if="${upcoming.codename} != null" class="version releasetrain partial" title="Partially available release train" th:text="${upcoming.name + ' (' + upcoming.codename + ')'}">STABLE_WITH_CODENAME</span>
+                </li>
+                <li>
+                    Latest stable BOM:
+                    <span th:if="${stable.codename} == null" class="version releasetrain" title="Stable release train" th:text="${stable.name}">STABLE</span>
+                    <span th:if="${stable.codename} != null" class="version releasetrain" title="Stable release train" th:text="${stable.name + ' (' + stable.codename + ')'}">STABLE_WITH_CODENAME</span>
+                </li>
+                <li th:if="${milestone.name} != null">
+                    Latest pre-release BOM:
+                    <span th:if="${milestone.codename} == null" class="version releasetrain pre" title="MILESTONE release train" th:text="${milestone.name}">MILESTONE</span>
+                    <span th:if="${milestone.codename} != null" class="version releasetrain pre" title="MILESTONE release train" th:text="${milestone.name + ' (' + milestone.codename + ')'}">MILESTONE_WITH_CODENAME</span>
+                </li>
+                <li>
+                    Latest BOMs in previous release trains:
+                    <span th:if="${oldBoms.versions} != null" th:each="bom : ${oldBoms.versions}">
+                        <span class="version releasetrain maintenance" th:text="${bom}">OLD BOM</span>&nbsp;
+                    </span>
+                    <span th:if="${oldBoms.badVersions} != null" th:each="bom : ${oldBoms.badVersions}">
+                        <span class="version releasetrain eol" th:text="${bom}">EOL BOM</span>&nbsp;
+                    </span>
+                </li>
+            </ul>
         </div>
     </div>
 </div>

--- a/src/main/sass/_main.scss
+++ b/src/main/sass/_main.scss
@@ -35,37 +35,6 @@ h1, h2, h3, h4 { font-family: $reactorFontSpecial }
   text-shadow: 0 0 0 white;
 }
 
-td.versionListGen {
-  background: $reactorPrimary;
-  color: white;
-}
-
-span.version {
-  display: inline;
-  font-family: monospace;
-  background: $reactorPrimary;
-  color: white;
-  border-radius: 3px;
-  font-size: 11px;
-  font-weight: normal;
-  padding: 2px 4px 2px;
-  line-height: 14px;
-  &.releasetrain {
-    background: $reactorTextColor;
-    &.pre {
-      background: linear-gradient(135deg,
-              $reactorTextColor 0%,$reactorTextColor 80%,
-              darkorange 81%,darkorange 100%);
-    }
-    &.hold {
-      background: darkgrey;
-    }
-  }
-  &.pre {
-      background: darkorange;
-    }
-  }
-
 // Application
 
 body {
@@ -304,11 +273,6 @@ section#applications {
       border-bottom:0 none;
     }
 
-    span.version {
-      height: auto;
-      font-weight: bold;
-      font-size: 11px;
-    }
     div.title, div.github, div.javadoc, div.reference {
       float: left;
     }

--- a/src/main/sass/reactor.scss
+++ b/src/main/sass/reactor.scss
@@ -49,3 +49,65 @@ $reactorFontSpecial3: "Varela Round",sans-serif;
 @import "responsive";
 @import "button";
 
+// Key classes for documentation badges and displaying versions
+
+td.versionListGen {
+  background: $reactorPrimary;
+  color: white;
+}
+
+span.version {
+  display: inline;
+  font-family: monospace;
+  background: $reactorPrimary;
+  color: white;
+  border-radius: 3px;
+  font-size: 11px;
+  font-weight: normal;
+  padding: 2px 4px 2px;
+  line-height: 14px;
+  &.releasetrain {
+    background: $reactorTextColor;
+    &.partial {
+      padding-left: 0;
+    }
+    &.partial::before {
+      content: "Part";
+      background: darkorange;
+      color: $reactorTextColor;
+      padding: 2px 4px;
+      margin-right: 6px;
+    }
+    &.maintenance {
+      background: dimgrey;
+    }
+    &.eol {
+      background: darkgrey;
+      color: white;
+      padding-left: 0;
+    }
+    &.eol::before {
+      content: "EoL";
+      background: darkorange;
+      color: $reactorTextColor;
+      padding: 2px 4px;
+      margin-right: 6px;
+    }
+    &.pre {
+      background: $reactorTextColor;
+      color: white;
+      padding-left: 0;
+    }
+    &.pre::before {
+      content: "Pre";
+      background: mediumpurple;
+      color: white;
+      padding: 2px 4px;
+      margin-right: 6px;
+    }
+  }
+  &.pre {
+    background: mediumpurple;
+  }
+}
+

--- a/src/main/sass/reactor.scss
+++ b/src/main/sass/reactor.scss
@@ -72,7 +72,7 @@ span.version {
       padding-left: 0;
     }
     &.partial::before {
-      content: "Part";
+      content: "WIP";
       background: darkorange;
       color: $reactorTextColor;
       padding: 2px 4px;
@@ -87,7 +87,7 @@ span.version {
       padding-left: 0;
     }
     &.eol::before {
-      content: "EoL";
+      content: "EOL";
       background: darkorange;
       color: $reactorTextColor;
       padding: 2px 4px;


### PR DESCRIPTION
This commit reorganizes the CSS for versions into the reactor.scss file.

 - renamed hold class to partial
 - added maintenance and eol classes for boms
 - use "::before" to distinguish special boms
 - change the color theme: orange if for "warnings", pre-releases are in
 purple now
 - removed gradient for pre-release boms, replaced with "Pre" ::before
 - End of life boms are taken from the badVersions list
 - removed conditional application of the pre class in docs template