### PR TITLE
Add /security-policy page (redirect to tanzu's own)

### DIFF
--- a/src/main/java/io/projectreactor/Application.java
+++ b/src/main/java/io/projectreactor/Application.java
@@ -101,6 +101,7 @@ public final class Application {
 		                    .host("0.0.0.0")
 		                    .port(8080)
 		                    .route(r -> r.file("/favicon.ico", contentPath.resolve("favicon.ico"))
+		                                 .get("/security-policy", (req, resp) -> resp.sendRedirect("https://tanzu.vmware.com/security"))
 		                                 .get("/", template("home"))
 		                                 .get("/docs", template("docs"))
 		                                 .get("/learn", template("learn"))

--- a/src/main/resources/static/templates/layout.html
+++ b/src/main/resources/static/templates/layout.html
@@ -157,7 +157,9 @@
                     © 2020 <a href="https://www.vmware.com/" class="pivotal">VMware, Inc.</a> or its affiliates. All rights reserved | <a
                         href="https://www.vmware.com/help/legal.html">Terms
                     of Use</a> |
-                    <a href="https://www.vmware.com/help/privacy.html">Privacy</a> | <span id="teconsent"></span>
+                    <a href="https://www.vmware.com/help/privacy.html">Privacy</a> |
+                    <a href="/security-policy">Security Policy</a> |
+                    <span id="teconsent"></span>
                 </div>
             </footer>
         </div>


### PR DESCRIPTION
This PR adds a `/security-policy` endpoint, that redirect to VMware Tanzu's
own security page. Additionally, the endpoint is displayed in the footer.