### PR TITLE
Bump all dependencies to latest releases and clean up some code

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,18 +53,18 @@ repositories {
 }
 
 dependencies {
-    compile("org.springframework:spring-core:5.1.7.RELEASE")
-    compile("io.projectreactor.netty:reactor-netty:0.8.9.RELEASE")
-    compile("io.projectreactor:reactor-core:3.2.10.RELEASE")
-    compile("org.thymeleaf:thymeleaf:3.0.9.RELEASE")
-    compile("org.yaml:snakeyaml:1.17")
-    compile("com.fasterxml.jackson.core:jackson-databind:2.10.1")
+    compile("org.springframework:spring-core:5.3.7")
+    compile("io.projectreactor.netty:reactor-netty:1.0.7")
+    compile("io.projectreactor:reactor-core:3.4.6")
+    compile("org.thymeleaf:thymeleaf:3.0.12.RELEASE")
+    compile("org.yaml:snakeyaml:1.28")
+    compile("com.fasterxml.jackson.core:jackson-databind:2.12.3")
     runtime("commons-logging:commons-logging:1.2")
-    runtime("org.slf4j:slf4j-api:1.7.21")
-    runtime("ch.qos.logback:logback-classic:1.1.7")
+    runtime("org.slf4j:slf4j-api:1.7.30")
+    runtime("ch.qos.logback:logback-classic:1.2.3")
 
-    testCompile("junit:junit:4.12")
-    testCompile("org.assertj:assertj-core:3.17.2")
+    testCompile("junit:junit:4.13.2")
+    testCompile("org.assertj:assertj-core:3.19.0")
 }
 
 val processResources = tasks.getByName("processResources")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ configurations.all {
 plugins {
     java
     application
-    id("com.github.johnrengelman.shadow") version "4.0.4"
+    id("com.github.johnrengelman.shadow") version "6.1.0"
     id("com.github.salomonbrys.gradle.sass") version "1.2.0"
 }
 
@@ -56,6 +56,7 @@ dependencies {
     implementation(platform("io.projectreactor:reactor-bom:2020.0.7"))
     implementation("io.projectreactor.netty:reactor-netty")
     implementation("io.projectreactor:reactor-core")
+    implementation("com.google.code.findbugs:jsr305:3.0.2")
     implementation("org.springframework:spring-core:5.3.7")
     implementation("org.thymeleaf:thymeleaf:3.0.12.RELEASE")
     implementation("org.yaml:snakeyaml:1.28")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,18 +53,19 @@ repositories {
 }
 
 dependencies {
-    compile("org.springframework:spring-core:5.3.7")
-    compile("io.projectreactor.netty:reactor-netty:1.0.7")
-    compile("io.projectreactor:reactor-core:3.4.6")
-    compile("org.thymeleaf:thymeleaf:3.0.12.RELEASE")
-    compile("org.yaml:snakeyaml:1.28")
-    compile("com.fasterxml.jackson.core:jackson-databind:2.12.3")
-    runtime("commons-logging:commons-logging:1.2")
-    runtime("org.slf4j:slf4j-api:1.7.30")
-    runtime("ch.qos.logback:logback-classic:1.2.3")
+    implementation(platform("io.projectreactor:reactor-bom:2020.0.7"))
+    implementation("io.projectreactor.netty:reactor-netty")
+    implementation("io.projectreactor:reactor-core")
+    implementation("org.springframework:spring-core:5.3.7")
+    implementation("org.thymeleaf:thymeleaf:3.0.12.RELEASE")
+    implementation("org.yaml:snakeyaml:1.28")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.12.3")
+    runtimeOnly("commons-logging:commons-logging:1.2")
+    runtimeOnly("org.slf4j:slf4j-api:1.7.30")
+    runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
 
-    testCompile("junit:junit:4.13.2")
-    testCompile("org.assertj:assertj-core:3.19.0")
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.assertj:assertj-core:3.19.0")
 }
 
 val processResources = tasks.getByName("processResources")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,20 +1,5 @@
-#
-# Copyright (c) 2011-Present Pivotal Software Inc, All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#       https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/io/projectreactor/Application.java
+++ b/src/main/java/io/projectreactor/Application.java
@@ -343,7 +343,7 @@ public final class Application {
 	}
 
 	private void startLog(DisposableServer c) {
-		System.out.printf("Server started in %d ms on: %s\n",
+		LOGGER.info("Server started in {} ms on: {}\n",
 				Duration.ofNanos(ManagementFactory.getThreadMXBean()
 						.getThreadCpuTime(Thread.currentThread().getId())).toMillis(), c.address());
 	}

--- a/src/main/java/io/projectreactor/ModuleUtils.java
+++ b/src/main/java/io/projectreactor/ModuleUtils.java
@@ -4,8 +4,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/test/java/io/projectreactor/ApplicationUtilsTest.java
+++ b/src/test/java/io/projectreactor/ApplicationUtilsTest.java
@@ -1,8 +1,5 @@
 package io.projectreactor;
 
-import java.io.IOException;
-import java.util.Map;
-
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import org.assertj.core.util.Streams;
 import org.junit.Test;

--- a/src/test/java/io/projectreactor/DocUtilsTest.java
+++ b/src/test/java/io/projectreactor/DocUtilsTest.java
@@ -16,7 +16,7 @@ public class DocUtilsTest {
 	private Module              urlModule;
 
 	@Before
-	public void setUp() throws Exception {
+	public void setUp() {
 		Module module = new Module("test", "group", "artifact");
 		module.addVersion("3.4.0")
 		      .addVersion("3.4.0-SNAPSHOT")
@@ -44,14 +44,14 @@ public class DocUtilsTest {
 	}
 
 	@Test
-	public void findModuleAndVersionNoSuchModule() throws Exception {
+	public void findModuleAndVersionNoSuchModule() {
 		Tuple2<Module, String> result = DocUtils.findModuleAndVersion(modules, "foo", "release");
 
 		assertThat(result).isNull();
 	}
 
 	@Test
-	public void findModuleAndVersionNoSuchVersion() throws Exception {
+	public void findModuleAndVersionNoSuchVersion() {
 		Tuple2<Module, String> result = DocUtils.findModuleAndVersion(modules,
 				"test",
 				"foo");
@@ -60,7 +60,7 @@ public class DocUtilsTest {
 	}
 
 	@Test
-	public void findModuleAndVersionLatestReleaseOldScheme() throws Exception {
+	public void findModuleAndVersionLatestReleaseOldScheme() {
 		Tuple2<Module, String> result = DocUtils.findModuleAndVersion(modules,
 				"testArchive",
 				"release");
@@ -75,7 +75,7 @@ public class DocUtilsTest {
 	}
 
 	@Test
-	public void findModuleAndVersionLatestReleaseNewScheme() throws Exception {
+	public void findModuleAndVersionLatestReleaseNewScheme() {
 		Tuple2<Module, String> result = DocUtils.findModuleAndVersion(modules,
 				"test",
 				"release");
@@ -90,7 +90,7 @@ public class DocUtilsTest {
 	}
 
 	@Test
-	public void findModuleAndVersionVersionTypeFallsBackToArchive() throws Exception {
+	public void findModuleAndVersionVersionTypeFallsBackToArchive() {
 		//for this one we assume a main module that doesn't have any release yet
 		Map<String, Module> customModules = new HashMap<>();
 		Module limitedNewModule = new Module("test", "group", "artifact");
@@ -110,7 +110,7 @@ public class DocUtilsTest {
 	}
 
 	@Test
-	public void findModuleAndVersionLatestSnapshotOldScheme() throws Exception {
+	public void findModuleAndVersionLatestSnapshotOldScheme() {
 		Tuple2<Module, String> result = DocUtils.findModuleAndVersion(modules,
 				"testArchive",
 				"snapshot");
@@ -125,7 +125,7 @@ public class DocUtilsTest {
 	}
 
 	@Test
-	public void findModuleAndVersionLatestSnapshot() throws Exception {
+	public void findModuleAndVersionLatestSnapshot() {
 		Tuple2<Module, String> result = DocUtils.findModuleAndVersion(modules,
 				"test",
 				"snapshot");
@@ -140,7 +140,7 @@ public class DocUtilsTest {
 	}
 
 	@Test
-	public void findModuleAndVersionLatestMilestoneOldScheme() throws Exception {
+	public void findModuleAndVersionLatestMilestoneOldScheme() {
 		Tuple2<Module, String> result = DocUtils.findModuleAndVersion(modules,
 				"testArchive",
 				"milestone");
@@ -155,7 +155,7 @@ public class DocUtilsTest {
 	}
 
 	@Test
-	public void findModuleAndVersionLatestMilestoneNewScheme() throws Exception {
+	public void findModuleAndVersionLatestMilestoneNewScheme() {
 		Tuple2<Module, String> result = DocUtils.findModuleAndVersion(modules,
 				"test",
 				"milestone");
@@ -170,7 +170,7 @@ public class DocUtilsTest {
 	}
 
 	@Test
-	public void findModuleAndVersionSpecificRelease() throws Exception {
+	public void findModuleAndVersionSpecificRelease() {
 		Tuple2<Module, String> result = DocUtils.findModuleAndVersion(modules,
 				"testArchive",
 				"3.0.5.RELEASE");
@@ -185,7 +185,7 @@ public class DocUtilsTest {
 	}
 
 	@Test
-	public void findModuleAndVersionSpecificReleaseInArchive() throws Exception {
+	public void findModuleAndVersionSpecificReleaseInArchive() {
 		Tuple2<Module, String> result = DocUtils.findModuleAndVersion(modules,
 				"test",
 				"3.0.5.RELEASE");
@@ -200,7 +200,7 @@ public class DocUtilsTest {
 	}
 
 	@Test
-	public void findVersionType() throws Exception {
+	public void findVersionType() {
 		assertThat(DocUtils.findVersionType("3.1.0.BUILD-SNAPSHOT")).isEqualTo("snapshot");
 		assertThat(DocUtils.findVersionType("3.4.0-SNAPSHOT")).isEqualTo("snapshot");
 		assertThat(DocUtils.findVersionType("snAPshOT")).isEqualTo("snapshot");

--- a/src/test/java/io/projectreactor/VersionTest.java
+++ b/src/test/java/io/projectreactor/VersionTest.java
@@ -214,20 +214,6 @@ public class VersionTest {
 		assertThat(v.style).isEqualTo(Version.VersionStyle.MAVEN_GRADLE);
 	}
 
-//	@Test
-//	public void matchesCustomSnapshotVersions() {
-//		assertThat("1.2.3.01.BUILD-SNAPSHOT").as("numeric only").matches(Module.VERSION_OLD_REGEXP);
-//		assertThat("1.2.3.0cusTom0.BUILD-SNAPSHOT").as("alphanumeric").matches(Module.VERSION_OLD_REGEXP);
-//		assertThat("1.2.3.cusTom.BUILD-SNAPSHOT").as("alphabetic only").matches(Module.VERSION_OLD_REGEXP);
-//	}
-//
-//	@Test
-//	public void matchesCustomReleaseVersions() {
-//		assertThat("1.2.3.01.RELEASE").as("numeric only").matches(Module.VERSION_OLD_REGEXP);
-//		assertThat("1.2.3.0cusTom0.RELEASE").as("alphanumeric").matches(Module.VERSION_OLD_REGEXP);
-//		assertThat("1.2.3.cusTom.RELEASE").as("alphabetic only").matches(Module.VERSION_OLD_REGEXP);
-//	}
-
 	@Test
 	public void doesntParseNull() {
 		assertThatIllegalArgumentException()


### PR DESCRIPTION
 - mainly, bump Reactor (netty + core) to latest Europium release (with BOM) from
 Californium (sic)
 - bump all other dependencies to their latest versions (Spring-Core, Jackson,
   Thymeleaf, AssertJ, etc...)
 - clean up code a bit (unused imports, unnecessary throws in tests,
   commented tests, use of sysout instead of logger...)
 - Bump Gradle to 6.9, using Shadow plugin's last compatible version 6.1.0 
   and newer dependency syntax
 - Add jsr305 dependency to avoid compilation warning