### PR TITLE
Add /maintenance page driven by maintenanceXxx env vars

### DIFF
--- a/src/main/java/io/projectreactor/Application.java
+++ b/src/main/java/io/projectreactor/Application.java
@@ -95,6 +95,12 @@ public final class Application {
 		LOGGER.info("Boms and modules loaded in " + (System.currentTimeMillis() - start) + "ms");
 
 		docsModel.put("oldBoms", modules.get("olderBoms"));
+		String maintenanceDate = System.getProperty("maintenanceDate", System.getenv("maintenanceDate"));
+		String maintenanceEnd = System.getProperty("maintenanceEnd", System.getenv("maintenanceEnd"));
+		if (maintenanceDate != null && maintenanceEnd != null) {
+			docsModel.put("maintenanceDate", maintenanceDate);
+			docsModel.put("maintenanceEnd", maintenanceEnd);
+		}
 		//templates will be resolved and parsed below during route setup
 
 		context = HttpServer.create()
@@ -105,6 +111,7 @@ public final class Application {
 		                                 .get("/", template("home"))
 		                                 .get("/docs", template("docs"))
 		                                 .get("/learn", template("learn"))
+		                                 .get("/maintenance", template("maintenance"))
 		                                 //.get("/project", template("project"))
 		                                 .get("/docs/{module}", this::listVersionsAndDocs)
 		                                 .get("/docs/", rewrite("docs/", "docs"))

--- a/src/main/resources/static/templates/maintenance.html
+++ b/src/main/resources/static/templates/maintenance.html
@@ -28,16 +28,14 @@
 </head>
 <body>
 <img src="assets/img/logo.jpg">
-<h1>:-\</h1>
-<h2>Sorry, something went wrong!
-<div th:if="${maintenanceEnd} != null">
-        This is due to an infrastructure maintenance scheduled on <strong th:text="${maintenanceDate}">YYYY/MM/DD</strong>.
-        We'll be back up by <strong th:text="${maintenanceEnd}">MAINTENANCE END</strong>.
+<div th:unless="${#strings.isEmpty(maintenanceEnd)}">
+    <h1>:-\</h1>
+    <h2>Sorry, something went wrong! This is due to an infrastructure maintenance scheduled on <strong th:text="${maintenanceDate}">YYYY/MM/DD</strong>. We'll be back up by <strong th:text="${maintenanceEnd}">MAINTENANCE END</strong>.</h2>
 </div>
-<div th:if="${maintenanceEnd} == null">
-    No maintenance is currently scheduled :(
+<div th:if="${#strings.isEmpty(maintenanceEnd)}">
+    <h1>:-(</h1>
+    <h2>Sorry, something went wrong and no maintenance is currently scheduled!</h2>
 </div>
-</h2>
 <p>Follow <a href="https://twitter.com/springops">@springops</a> for updates.</p>
 <div style="display: none">::CLOUDFLARE_ERROR_500S_BOX::</div>
 </body>

--- a/src/main/resources/static/templates/maintenance.html
+++ b/src/main/resources/static/templates/maintenance.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Project Reactor - Something went wrong</title>
+    <meta name="description" content="Something went wrong"/>
+    <style>
+        h1 {
+            font-family: Metropolis,sans-serif;
+            color: rgb(94, 169, 66);
+            text-align: center;
+            font-size: 130px;
+            font-weight: 500;
+            line-height: 110px;
+            margin: 0;
+            padding: 0 0 1.5rem;
+        }
+        h2, h3, h4, h5, html, p strong {
+            font-family: Metropolis,sans-serif;
+            font-weight: 400;
+            text-align: center;
+            color: #191e1e;
+        }
+        html {
+            font-size: 100%;
+            font-family: Open Sans,sans-serif;
+        }
+    </style>
+</head>
+<body>
+<img src="assets/img/logo.jpg">
+<h1>:-\</h1>
+<h2>Sorry, something went wrong!
+<div th:if="${maintenanceEnd} != null">
+        This is due to an infrastructure maintenance scheduled on <strong th:text="${maintenanceDate}">YYYY/MM/DD</strong>.
+        We'll be back up by <strong th:text="${maintenanceEnd}">MAINTENANCE END</strong>.
+</div>
+<div th:if="${maintenanceEnd} == null">
+    No maintenance is currently scheduled :(
+</div>
+</h2>
+<p>Follow <a href="https://twitter.com/springops">@springops</a> for updates.</p>
+<div style="display: none">::CLOUDFLARE_ERROR_500S_BOX::</div>
+</body>
+</html>


### PR DESCRIPTION
The environment variables change the message to indicate there is an
expected maintenance window:
 - `maintenanceDate` is the YYYY/MM/DD date of the scheduled maintenance
 - `maintenanceEnd` is the expected end time of said maintenance

Both are Strings interpolated in the message, so there's no format
enforced.

The page is kept minimal (no external css or scripts) as it is
intended to be cached for the CDN to serve in case of errors, and
the CDN puts a size limit of such a page.
