### PR TITLE
Introduce Spotless and update copyright notice headers

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ assignees: ''
 
 <!--- /!\ Make sure to follow the Contribution Guidelines, notably for security issues and questions:
 https://github.com/reactor/.github/blob/master/CONTRIBUTING.md
-https://pivotal.io/security
+https://tanzu.vmware.com/security
 https://github.com/reactor/.github/blob/master/CONTRIBUTING.md#question-do-you-have-a-question
 -->
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,20 @@ jobs:
         with:
           github_token: ${{ github.token }}
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 #for spotless ratchet
       - uses: actions/setup-java@v1
         with:
           java-version: 8
       - uses: eskatos/gradle-command-action@v1
-        name: gradle
+        name: license header
+        with:
+          arguments: spotlessCheck -PspotlessFrom=origin/${{ github.base_ref }}
+          wrapper-cache-enabled: true
+          dependencies-cache-enabled: true
+          configuration-cache-enabled: true
+      - uses: eskatos/gradle-command-action@v1
+        name: tests
         with:
           wrapper-cache-enabled: true
           dependencies-cache-enabled: true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/codequality/spotless/licenseSlashstarStyle.txt
+++ b/codequality/spotless/licenseSlashstarStyle.txt
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) $YEAR VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+

--- a/src/main/java/io/projectreactor/Application.java
+++ b/src/main/java/io/projectreactor/Application.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2015-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.projectreactor;
 
 import java.io.IOException;

--- a/src/main/java/io/projectreactor/ApplicationUtils.java
+++ b/src/main/java/io/projectreactor/ApplicationUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor;
 
 import java.util.Iterator;

--- a/src/main/java/io/projectreactor/Bom.java
+++ b/src/main/java/io/projectreactor/Bom.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-Present Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.projectreactor;
 
 /**

--- a/src/main/java/io/projectreactor/DocUtils.java
+++ b/src/main/java/io/projectreactor/DocUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor;
 
 import java.util.Map;

--- a/src/main/java/io/projectreactor/Module.java
+++ b/src/main/java/io/projectreactor/Module.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/projectreactor/ModuleUtils.java
+++ b/src/main/java/io/projectreactor/ModuleUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2019-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor;
 
 import java.io.IOException;

--- a/src/main/java/io/projectreactor/Version.java
+++ b/src/main/java/io/projectreactor/Version.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor;
 
 import java.util.Comparator;

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,11 +1,11 @@
 <!--
-  ~ Copyright (c) 2011-Present Pivotal Software Inc, All Rights Reserved.
+  ~ Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~       https://www.apache.org/licenses/LICENSE-2.0
+  ~   https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/static/assets/js/sidebar.js
+++ b/src/main/resources/static/assets/js/sidebar.js
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2015-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/static/templates/docs.html
+++ b/src/main/resources/static/templates/docs.html
@@ -1,11 +1,11 @@
 <!--
-  ~ Copyright (c) 2011-Present Pivotal Software Inc, All Rights Reserved.
+  ~ Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~       https://www.apache.org/licenses/LICENSE-2.0
+  ~   https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/static/templates/home.html
+++ b/src/main/resources/static/templates/home.html
@@ -1,11 +1,11 @@
 <!--
-  ~ Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+  ~ Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~       https://www.apache.org/licenses/LICENSE-2.0
+  ~   https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/static/templates/layout.html
+++ b/src/main/resources/static/templates/layout.html
@@ -1,11 +1,11 @@
 <!--
-  ~ Copyright (c) 2011-Present Pivotal Software Inc, All Rights Reserved.
+  ~ Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~       https://www.apache.org/licenses/LICENSE-2.0
+  ~   https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/static/templates/learn.html
+++ b/src/main/resources/static/templates/learn.html
@@ -1,11 +1,11 @@
 <!--
-  ~ Copyright (c) 2011-Present Pivotal Software Inc, All Rights Reserved.
+  ~ Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~       https://www.apache.org/licenses/LICENSE-2.0
+  ~   https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/static/templates/listVersions.html
+++ b/src/main/resources/static/templates/listVersions.html
@@ -1,11 +1,11 @@
 <!--
-  ~ Copyright (c) 2011-Present Pivotal Software Inc, All Rights Reserved.
+  ~ Copyright (c) 2019-2021 VMware Inc. or its affiliates, All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~       https://www.apache.org/licenses/LICENSE-2.0
+  ~   https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/sass/_learn.scss
+++ b/src/main/sass/_learn.scss
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/sass/_main.scss
+++ b/src/main/sass/_main.scss
@@ -1,11 +1,11 @@
-/*!
- * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+/*
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/sass/_responsive.scss
+++ b/src/main/sass/_responsive.scss
@@ -1,11 +1,11 @@
-/*!
- * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+/*
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/sass/reactor.scss
+++ b/src/main/sass/reactor.scss
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/projectreactor/ApplicationUtilsTest.java
+++ b/src/test/java/io/projectreactor/ApplicationUtilsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor;
 
 import io.netty.handler.codec.http.DefaultHttpHeaders;

--- a/src/test/java/io/projectreactor/DocUtilsTest.java
+++ b/src/test/java/io/projectreactor/DocUtilsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor;
 
 import java.util.HashMap;

--- a/src/test/java/io/projectreactor/ModuleTest.java
+++ b/src/test/java/io/projectreactor/ModuleTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2019-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor;
 
 import java.util.Arrays;

--- a/src/test/java/io/projectreactor/ModuleUtilsTest.java
+++ b/src/test/java/io/projectreactor/ModuleUtilsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2019-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor;
 
 import java.io.BufferedReader;

--- a/src/test/java/io/projectreactor/VersionTest.java
+++ b/src/test/java/io/projectreactor/VersionTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectreactor;
 
 import java.util.Arrays;


### PR DESCRIPTION
To be merged-with-rebase

﻿- [build] Add Spotless plugin to enforce license headers
- [chores] Copyright switch from Pivotal to VMware, polish headers
