### PR TITLE
Improve discoverability of security policy, add security-txt

### DIFF
--- a/src/main/java/io/projectreactor/Application.java
+++ b/src/main/java/io/projectreactor/Application.java
@@ -108,7 +108,10 @@ public final class Application {
 		                    .host("0.0.0.0")
 		                    .port(8080)
 		                    .route(r -> r.file("/favicon.ico", contentPath.resolve("favicon.ico"))
-		                                 .get("/security-policy", (req, resp) -> resp.sendRedirect("https://tanzu.vmware.com/security"))
+		                                 .get("/security-policy", (req, resp) -> resp.sendRedirect("https://www.vmware.com/support/policies/security_response.html"))
+		                                 .file("/.well-known/security.txt", contentPath.resolve(".well-known/security.txt"))
+		                                 //the dot in .well-known is confusing to netty. that said, we're not expected to serve an index for this directory so let's cover the case explicitly
+		                                 .get("/.well-known", pageNotFound())
 		                                 .get("/", template("home"))
 		                                 .get("/docs", template("docs"))
 		                                 .get("/learn", template("learn"))

--- a/src/main/resources/static/.well-known/security.txt
+++ b/src/main/resources/static/.well-known/security.txt
@@ -1,0 +1,6 @@
+Contact: mailto:security@vmware.com
+Contact: https://projectreactor.io/security-policy
+Contact: https://tanzu.vmware.com/security
+Expires: 2023-08-31T22:00:00.000Z
+Encryption: https://kb.vmware.com/s/article/1055
+Policy: https://projectreactor.io/security-policy

--- a/src/main/resources/static/templates/layout.html
+++ b/src/main/resources/static/templates/layout.html
@@ -116,6 +116,7 @@
                         <nav>
                             <ul>
                                 <li class="heading">Documentation</li>
+                                <li><a href="/security-policy">Security Policy</a></li>
                                 <li><a href="/docs">All projects (latest release trains,<br>ref. & javadoc links...)</a></li>
                                 <li><a href="/docs/core/">List of all <span class="version releasetrain">Core</span> versions</a></li>
                                 <li><a href="/docs/netty/">List of all <span class="version releasetrain">Netty</span> versions</a></li>


### PR DESCRIPTION
This commit changes the URL for /security-policy to one on VMware site
that does indeed describe the full security policy.

It adds a link to /security-policy in the site's footer.

It also introduces a /.well-known/security.txt file that conforms to the
draft security-txt spec, see https://securitytxt.org/.

Fixes #69.
