### PR TITLE
Can't deactivate Milestone links for artifacts which don't have milestone versions.

### DIFF
--- a/src/main/resources/boms.yml
+++ b/src/main/resources/boms.yml
@@ -56,12 +56,12 @@ name: 2023.0.0-M1
 codename: G
 coreVersion: 3.6.0-M1
 testVersion: 3.6.0-M1
-nettyVersion: 1.1.9
-extraVersion: 3.5.1
-adapterVersion: 3.5.1
-kafkaVersion: 1.3.19
-poolVersion: 1.0.1
-kotlinVersion: 1.2.2
+#nettyVersion: 1.1.9
+#extraVersion: 3.5.1
+#adapterVersion: 3.5.1
+#kafkaVersion: 1.3.19
+#poolVersion: 1.0.1
+#kotlinVersion: 1.2.2
 ---
 #this special pseudo-BOM is used to display milestones that are released outside of a release train.
 #they appear beneath a regular milestone BOM and activate the link to Milestone javadoc/refdoc.

--- a/src/main/resources/static/templates/docs.html
+++ b/src/main/resources/static/templates/docs.html
@@ -499,7 +499,7 @@
             <div class="reference">
                 <strong>Reference</strong><br />
                 <a href="/docs/netty/release/reference/docs/index.html">Release</a> |
-                <span th:if="${milestone.testVersion} != null OR ${oobmilestone.nettyVersion} != null"><a href="/docs/netty/milestone/reference/docs/index.html">Milestone</a> |</span>
+                <span th:if="${milestone.nettyVersion} != null OR ${oobmilestone.nettyVersion} != null"><a href="/docs/netty/milestone/reference/docs/index.html">Milestone</a> |</span>
                 <a href="/docs/netty/snapshot/reference/docs/index.html">Snapshot</a>
             </div>
         </article>


### PR DESCRIPTION
When doing the 2022.0.9 / 2023.0.0-M1 / 2020.0.34 releases, there are some issues with the projectreactor site:

For the 2023.0.0-M1 milestone version, only the `Reactor Core` and the `Reactor Test` should have some `Milestone` links, and other artifacts (like Reactor Netty, Reactor Pool) should not have such links, because only Reactor Core/Test are part of the 2023.0.0-M1.

For example, when we browse the site, the `Milestone` links are enabled for the following artifact:

- reactor extra (Javadoc with milestone 3.5.0-RC1)
- reactor netty (Javadoc and Reference with milestone 1.1.0-RC1)
- reactor adapter (Javadoc with milestone 3.5.0-RC1)
- reactor kotling extensions (Javadoc with milestone 1.2.0-RC1)
- reactor-pool (Javadoc with milestone 1.0.0-RC1)

This PR is an attempt to fix the problems with two fixes which allows to hide artifacts `Milestone` links for the components which are not part of the 2023.0.0-M1 milestone:

1) first fix in boms.yml, when the artifacts which are not part of the 2023.0.0-M1 are commented

2) annother fix is in docs.html, where the `Reactor Netty` Milestone link for the `Reference` is included even if it commented in the bom.yml (there is a wrong test which is testing `milestone.testVersion` instead of `milestone. nettyVersion`).

Without this PR, currently, for example we have the Milestone links that are appearing for Reactor Netty and Reactor Adapter:
![Screenshot 2023-07-12 at 21 42 04](https://github.com/reactor/projectreactor.io/assets/650758/575c1467-30a7-4080-970f-d48758ecbae7)

and with the proposed PR, the Milestone links are not displayed anymore:

![Screenshot 2023-07-12 at 21 44 29](https://github.com/reactor/projectreactor.io/assets/650758/0d601d5f-2bb0-4dc2-8657-abd0212159ca)

Admittedly, maybe there is still a problem, because the Reactor Netty and Reactor Adapter release trains don't contain anymore the 2023.0.0-M1 version ...