### PR TITLE
Update allowed spring versions in renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,5 +33,9 @@
       "groupSlug": "jsr305",
       "allowedVersions": "=3.0.1"
     }
+    {
+      "matchPackageNames": ["spring"],
+      "allowedVersions": "<6"
+    }
   ]
 }


### PR DESCRIPTION
This project is built with Java 8, while Spring Framework 6 requires Java 17.