### PR TITLE
Fix wrong self-hosted label in DEPLOY workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ permissions: read-all
 
 jobs:
   deploy-cf:
-    runs-on: reactor-self-hosted
+    runs-on: reactor-gha-01
     env:
       APPNAME: ${{ github.event.inputs.application }}
       ROUTE: ${{ github.event.inputs.application == 'projectreactor' && 'https://projectreactor.io' || 'https://projectreactor-test.wdc-08-pcf1-pws-apps.oc.vmware.com' }}


### PR DESCRIPTION
The DEPLOY workflow was using a wrong self-hosted runner label, we apparently need to use `reactor-gha-01` label, not `reactor-self-hosted`

See https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/using-self-hosted-runners-in-a-workflow which describes how to obtain the label of a specific self-hosted label.

