### PR TITLE
Set correct runs-on - attempt 3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ permissions: read-all
 
 jobs:
   deploy-cf:
-    runs-on: reactor-gha-01
+    runs-on: self-hosted
     env:
       APPNAME: ${{ github.event.inputs.application }}
       ROUTE: ${{ github.event.inputs.application == 'projectreactor' && 'https://projectreactor.io' || 'https://projectreactor-test.wdc-08-pcf1-pws-apps.oc.vmware.com' }}


### PR DESCRIPTION
The runs-on in the DEPLOY workflow seems to not yet work, let's try another label:
according to https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/using-self-hosted-runners-in-a-workflow, we can try `runs-on: self-hosted`

