### PR TITLE
Use Docker Hub read-only token

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,8 @@ jobs:
         name: build
         with:
           arguments: build
+      - name: Docker Hub Login
+        run: docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Deploy to CF primary
         if: inputs.application == 'projectreactor'
         uses: citizen-of-planet-earth/cf-cli-action@v2


### PR DESCRIPTION
The cf-cli-action GH action used to deploy the site to cloud foundry is using Docker, but since the self-runner is inside the private network, it is sharing the gateway IP address. When too many unauthenticated docker pull requests come from the same IP, it will get temporarily blocked by Docker, and the DEPLOY workflow fails with a "toomanyrequests: You have reached your pull rate limit" error.

To work around, a Docker Hub read-only token has been created in the form of a GitHub Secret that can be used when logging to Docker Hub.