### PR TITLE
Do not use  java_buildpack_offline in CF manifest.yml

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ applications:
   memory: 1G
   path: ./build/libs/projectreactor-home.jar
   buildpacks:
-    - java_buildpack_offline
+    - https://github.com/cloudfoundry/java-buildpack.git
   routes:
     - route: ((route))
   disk_quota: 1024M


### PR DESCRIPTION
When running the DEPLOY workflow in the production site, it does not work and we have the following error in the workflow logs:

```
Staging app and tracing logs...
   Downloading java_buildpack_offline...
   Downloaded java_buildpack_offline
   Cell d0d28ca5-e30b-4206-866b-a0[55](https://github.com/reactor/projectreactor.io/actions/runs/7539144911/job/20521053088#step:7:56)91d7b0ac creating container for instance 52ea2cb3-54ee-4216-ac1c-9f5ff87d5337
   Cell d0d28ca5-e30b-4206-866b-a05591d7b0ac successfully created container for instance 52ea2cb3-54ee-4216-ac1c-9f5ff87d5337
   Downloading app package...
   Downloading build artifacts cache...
   Downloaded app package (41.7M)
   Downloaded build artifacts cache (4[60](https://github.com/reactor/projectreactor.io/actions/runs/7539144911/job/20521053088#step:7:61).1M)
   -----> Java Buildpack v4.45 (offline) | https://github.com/cloudfoundry/java-buildpack#02aeb370
   [Buildpack]                      ERROR Finalize failed with exception #<RuntimeError: Unable to find cached file for https://java-buildpack.cloudfoundry.org/jvmkill/bionic/x86_[64](https://github.com/reactor/projectreactor.io/actions/runs/7539144911/job/20521053088#step:7:65)/jvmkill-1.16.0_RELEASE.so>
   Unable to find cached file for https://java-buildpack.cloudfoundry.org/jvmkill/bionic/x86_64/jvmkill-1.16.0_RELEASE.so
   Failed to compile droplet: Failed to run finalize script: exit status 1
```

it seems to be related to the Java Buildpack not being able to find a cached file.
in Bamboo, the buildpack used is `https://github.com/cloudfoundry/java-buildpack.git`, but we are currently using `java_buildpack_offline`.

Let's configure the buildpacks to https://github.com/cloudfoundry/java-buildpack.git and use the same bildpacks that is used by Bamboo.