### PR TITLE
Hide Route-Test URL and avoid leaking API urls in the logs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,8 +21,16 @@ jobs:
     runs-on: self-hosted
     env:
       APPNAME: ${{ github.event.inputs.application }}
-      ROUTE: ${{ github.event.inputs.application == 'projectreactor' && 'https://projectreactor.io' || 'https://projectreactor-test.wdc-08-pcf1-pws-apps.oc.vmware.com' }}
+      ROUTE: ${{ github.event.inputs.application == 'projectreactor' && 'https://projectreactor.io' || secrets.CF_ROUTE_TEST }}
     steps:
+      - name: Mask CF API urls
+        run: |-
+          # The CF cli may log the API urls in case of errors, but without the "https://" prefix, so mask API urls 
+          # without the protocol prefix. 
+          primary_api=$(echo ${{ secrets.CF_PRIMARY_API }} | sed 's/^https:\/\///')
+          echo "::add-mask::$primary_api"
+          secondary_api=$(echo ${{ secrets.CF_SECONDARY_API }} | sed 's/^https:\/\///')
+          echo "::add-mask::$secondary_api"
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           fetch-depth: 0 #for spotless ratchet


### PR DESCRIPTION
This PR is addressing two things:

1) First, the CF route test URL is not hard coded anymore and is retrieved from a CF_ROUTE_TEST secret

2) in case the CF API URL is unreachable, the `cf api`command that is internally executed by the `cf-cli-action` is currently logging to stderr a message that includes the CF API URL.

For example, let's say the CF_PRIMARY_API secret is configured to https://api.my-cloud-foundry.com, and if the endpoint is unreachable, then we will have a the URL logged in the error message:

```
Request error: Get "***": dial tcp: lookup api.my-cloud-foundry.com: no such host
```
It's because in the secret, we include the "https://" for the API URL, but when it can't connect, the "cf api" command logs an error with the API URL, but without the "https://" part. That's why the URL is not masked by GH.

To work around, we need to manually mask the API URLs without the `https://` prefix.

Note: we could also store the API URLs in the secrets without "https://" prefix, but better is to protect agains such situation.

Fixes #133 
