### PR TITLE
Temporary workaround to re-enable release javadocs

### DIFF
--- a/src/main/resources/static/templates/docs.html
+++ b/src/main/resources/static/templates/docs.html
@@ -160,7 +160,7 @@
             </div>
             <div class="javadoc">
                 <strong>Javadoc</strong><br />
-                <a href="/docs/core/release/api/">Release</a> |
+                <a href="https://javadoc.io/doc/io.projectreactor/reactor-core/latest/index.html">Release</a> |
                 <span th:if="(${milestone.coreVersion} != null AND ${milestone.coreVersion.matches('.*-M\\d+$')}) OR ${oobmilestone.coreVersion} != null"><a href="/docs/core/milestone/api/">Milestone</a> |</span>
                 <a href="/docs/core/snapshot/api/">Snapshot</a> |
 <!--                <a href="/docs/core/release/kdoc-api/">Kotlin Doc</a>-->
@@ -276,7 +276,7 @@
             </div>
             <div class="javadoc">
                 <strong>Javadoc</strong><br />
-                <a href="/docs/test/release/api/">Release</a> |
+                <a href="https://javadoc.io/doc/io.projectreactor/reactor-test/latest/index.html">Release</a> |
                 <span th:if="(${milestone.testVersion} != null AND ${milestone.testVersion.matches('.*-M\\d+$')}) OR ${oobmilestone.testVersion} != null"><a href="/docs/test/milestone/api/">Milestone</a> |</span>
                 <a href="/docs/test/snapshot/api/">Snapshot</a> |
 <!--                <a href="/docs/test/release/kdoc-api/">Kotlin Doc</a>-->
@@ -388,7 +388,7 @@
             </div>
             <div class="reference">
                 <strong>Javadoc</strong><br />
-                <a href="/docs/extra/release/api/">Release</a> |
+                <a href="https://javadoc.io/doc/io.projectreactor.addons/reactor-extra/latest/index.html">Release</a> |
                 <span th:if="(${milestone.extraVersion} != null AND ${milestone.extraVersion.matches('.*-M\\d+$')}) OR ${oobmilestone.extraVersion} != null"><a href="/docs/extra/milestone/api/">Milestone</a> |</span>
                 <a href="/docs/extra/snapshot/api/">Snapshot</a>
             </div>
@@ -492,7 +492,7 @@
             </div>
             <div class="javadoc">
                 <strong>Javadoc</strong> <br/>
-                <a href="/docs/netty/release/api/">Release</a> |
+                <a href="https://javadoc.io/doc/io.projectreactor.netty/reactor-netty/latest/index.html">Release</a> |
                 <span th:if="(${milestone.nettyVersion} != null AND ${milestone.nettyVersion.matches('.*-M\\d+$')}) OR ${oobmilestone.nettyVersion} != null"><a href="/docs/netty/milestone/api/">Milestone</a> |</span>
                 <a href="/docs/netty/snapshot/api/">Snapshot</a>
             </div>
@@ -601,7 +601,7 @@
             </div>
             <div class="reference">
                 <strong>Javadoc</strong><br />
-                <a href="/docs/adapter/release/api/">Release</a> |
+                <a href="https://javadoc.io/doc/io.projectreactor.addons/reactor-adapter/latest/index.html">Release</a> |
                 <span th:if="(${milestone.adapterVersion} != null AND ${milestone.adapterVersion.matches('.*-M\\d+$')}) OR ${oobmilestone.adapterVersion} != null"><a href="/docs/adapter/milestone/api/">Milestone</a> |</span>
                 <a href="/docs/adapter/snapshot/api/">Snapshot</a>
             </div>
@@ -703,7 +703,7 @@
             </div>
             <div class="javadoc">
                 <strong>Javadoc</strong> <br/>
-                <a href="/docs/kafka/release/api/">Release</a> |
+                <a href="https://javadoc.io/doc/io.projectreactor.kafka/reactor-kafka/latest/index.html">Release</a> |
                 <a href="/docs/kafka/snapshot/api/">Snapshot</a>
             </div>
             <div class="reference">
@@ -819,7 +819,7 @@
 <!--            </div>-->
             <div class="javadoc">
                 <strong>Javadoc (temporarily instead of Kotlin Doc)</strong><br />
-                <a href="/docs/kotlin/release/api/">Release</a> |
+                <a href="https://javadoc.io/doc/io.projectreactor.kotlin/reactor-kotlin-extensions/latest/index.html">Release</a> |
                 <span th:if="(${milestone.kotlinVersion} != null AND ${milestone.kotlinVersion.matches('.*-M\\d+$')}) OR ${oobmilestone.kotlinVersion} != null"><a href="/docs/kotlin/milestone/api/">Milestone</a> |</span>
                 <a href="/docs/kotlin/snapshot/api/">Snapshot</a>
             </div>
@@ -929,7 +929,7 @@
             </div>
             <div class="javadoc">
                 <strong>Javadoc</strong> <br/>
-                <a href="/docs/rabbitmq/release/api/">Release</a> |
+                <a href="https://javadoc.io/doc/io.projectreactor.rabbitmq/reactor-rabbitmq/latest/index.html">Release</a> |
                 <span th:if="(${milestone.rabbitVersion} != null AND ${milestone.rabbitVersion.matches('.*-M\\d+$')}) OR ${oobmilestone.rabbitVersion} != null"><a href="/docs/rabbitmq/milestone/api/">Milestone</a> |</span>
                 <a href="/docs/rabbitmq/snapshot/api/">Snapshot</a>
             </div>
@@ -1041,7 +1041,7 @@
             </div>
             <div class="javadoc">
                 <strong>Javadoc</strong> <br/>
-                <a href="/docs/pool/release/api/">Release</a> |
+                <a href="https://javadoc.io/doc/io.projectreactor.addons/reactor-pool/latest/index.html">Release</a> |
                 <span th:if="(${milestone.poolVersion} != null AND ${milestone.poolVersion.matches('.*-M\\d+$')}) OR ${oobmilestone.poolVersion} != null"><a href="/docs/pool/milestone/api/">Milestone</a> |</span>
                 <a href="/docs/pool/snapshot/api/">Snapshot</a>
             </div>


### PR DESCRIPTION
This temporary fix is re enabling released javadoc links, because currently, the projectreactor site is unable to scrape module versions from maven central.

This PR can  be reverted once there is no more 403 when accessing to maven central lucene URLs.

Fixes #143

PS: the javadoc links should be re-enabled by this PR, but the released reference docs links are still unreachable.