### PR TITLE
Fix template labels for preparation of reactorbot removal

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: type/bug
+labels: status/need-triage, type/bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/learn-page-resource-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/learn-page-resource-suggestion.md
@@ -2,7 +2,7 @@
 name: Learn page resource suggestion
 about: Suggest a resource to be added to the curated learn page
 title: 'Learn page suggestion: '
-labels: area/learn
+labels: status/need-triage, area/learn
 assignees: ''
 
 ---


### PR DESCRIPTION
add need-triage label in custom ISSUE templates for preparation of removal of reactorbot.