### PR TITLE
Fix deprecated set-output in deploy-to-azure workflow

### DIFF
--- a/.github/workflows/deploy-to-azure.yml
+++ b/.github/workflows/deploy-to-azure.yml
@@ -63,8 +63,8 @@ jobs:
             fi
             echo 'new deployment: ' $NEWDEPLOYMENT
             echo 'active deployment': $ACTIVEDEPLOYMENT
-            echo "::set-output name=NEWDEPLOYMENT::$NEWDEPLOYMENT"
-            echo "::set-output name=ACTIVEDEPLOYMENT::$ACTIVEDEPLOYMENT"
+            echo "NEWDEPLOYMENT=$NEWDEPLOYMENT" >> $GITHUB_OUTPUT
+            echo "ACTIVEDEPLOYMENT=$ACTIVEDEPLOYMENT" >> $GITHUB_OUTPUT
             NEWDEPLOYMENTEXISTS=$(az spring app deployment list --app ${{env.APP_NAME}} --query "[?name=='$NEWDEPLOYMENT'].name" -o tsv -s ${{env.SERVICE_NAME}} -g ${{env.GROUP_NAME}})
             if [ "$NEWDEPLOYMENTEXISTS" = "$NEWDEPLOYMENT" ]; then
               echo $NEWDEPLOYMENT ' already exists'


### PR DESCRIPTION
Avoid deprecation warning when running the deploy-to-azure workflow:

```
[deploy](https://github.com/reactor/projectreactor.io/actions/runs/8248158254/job/22557859882#step:7:54)
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ or https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs for more context.