### PR TITLE
remove SpringOne CFP banner

### DIFF
--- a/src/main/resources/static/templates/layout.html
+++ b/src/main/resources/static/templates/layout.html
@@ -166,9 +166,6 @@
    <div id="sidebar"></div>
    <div class="application-main-content website">
     <div class="application-content">
-     <p id="skinny-banner">
-      SpringOne Call for papers is open—<a href="https://springone.io" target="_blank">Submit your talk</a> by May 3!
-     </p>
      <header id="header">
       <a href="#" data-toggle=".application-container" id="sidebar-toggle">
        <span class="fa fa-bars"></span>

--- a/src/main/sass/_main.scss
+++ b/src/main/sass/_main.scss
@@ -53,15 +53,6 @@ body {
   margin: 0 auto;
 }
 
-// Banner
-
-#skinny-banner {
-  text-align: center;
-  @media(max-width: 800px) {
-    display: none;
-  }
-}
-
 // Header
 
 #header {


### PR DESCRIPTION
remove the SpringOne CFP banner, as the CFP closes today.
