### PR TITLE
Remove `gradle/actions/setup-gradle` deprecated functionality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 8
-      - uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda
-        name: license header
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@fd87365911aa12c016c307ea21313f351dc53551
+      - name: license header
         if: ${{ github.event_name == 'pull_request' }}
-        with:
-          arguments: spotlessCheck -PspotlessFrom=origin/${{ github.base_ref }}
-      - uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda
-        name: tests
-        with:
-          arguments: check -x spotlessCheck
+        run: ./gradlew spotlessCheck -PspotlessFrom=origin/${{ github.base_ref }}
+      - name: tests
+        run: ./gradlew check -x spotlessCheck

--- a/.github/workflows/deploy-to-azure.yml
+++ b/.github/workflows/deploy-to-azure.yml
@@ -29,10 +29,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 8
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@fd87365911aa12c016c307ea21313f351dc53551
       - name: Build
-        uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda
-        with:
-          arguments: build -x spotlessCheck
+        run: ./gradlew build -x spotlessCheck
       - name: Login Via Azure CLI
         uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a # v2
         with:


### PR DESCRIPTION
The 'arguments' parameter is no longer supported for gradle/actions/setup-gradle. See https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated