### PR TITLE
Fix the link to "Choosing an operator"

### DIFF
--- a/src/main/resources/static/templates/docs.html
+++ b/src/main/resources/static/templates/docs.html
@@ -171,7 +171,7 @@
                 <span th:if="(${milestone.coreVersion} != null AND ${milestone.coreVersion.matches('.*(-M|-RC)\\d+$')}) OR ${oobmilestone.coreVersion} != null"><a href="/docs/core/milestone/reference/">Milestone</a> |</span>
                 <a href="/docs/core/snapshot/reference/">Snapshot</a>
                 <br />
-                <a href="/docs/core/release/reference/docs/index.html#which-operator">Choosing an Operator</a>
+                <a href="/docs/core/release/reference/apdx-operatorChoice.html">Choosing an Operator</a>
             </div>
         </article>
 


### PR DESCRIPTION
Fix the link.

![image](https://github.com/user-attachments/assets/c07036cb-59c3-459a-83ef-d62cbd8febf3)
